### PR TITLE
fix CreateWindowEx

### DIFF
--- a/user32.go
+++ b/user32.go
@@ -1815,8 +1815,8 @@ func CreatePopupMenu() HMENU {
 	return HMENU(ret)
 }
 
-func CreateWindowEx(dwExStyle uint32, lpClassName, lpWindowName *uint16, dwStyle uint32, x, y, nWidth, nHeight int32, hWndParent HWND, hMenu HMENU, hInstance HINSTANCE, lpParam unsafe.Pointer) HWND {
-	ret, _, _ := syscall.Syscall12(createWindowEx, 12,
+func CreateWindowEx(dwExStyle uint32, lpClassName, lpWindowName *uint16, dwStyle uint32, x, y, nWidth, nHeight int32, hWndParent HWND, hMenu HMENU, hInstance HINSTANCE, lpParam unsafe.Pointer) (HWND, syscall.Errno) {
+	ret, _, err := syscall.Syscall12(createWindowEx, 12,
 		uintptr(dwExStyle),
 		uintptr(unsafe.Pointer(lpClassName)),
 		uintptr(unsafe.Pointer(lpWindowName)),
@@ -1830,7 +1830,7 @@ func CreateWindowEx(dwExStyle uint32, lpClassName, lpWindowName *uint16, dwStyle
 		uintptr(hInstance),
 		uintptr(lpParam))
 
-	return HWND(ret)
+	return HWND(ret), err
 }
 
 func DeferWindowPos(hWinPosInfo HDWP, hWnd, hWndInsertAfter HWND, x, y, cx, cy int32, uFlags uint32) HDWP {


### PR DESCRIPTION
This should fix the incompatibility with Go 1.4.2. A fix for walk is also necessary and is contained in another pull request. I tested successfully all the examples.