### PR TITLE
Add build tags to allow this library to be included in a cross platform projects

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,9 +13,10 @@ Alexander Neumann <an2048@googlemail.com>
 Anton Lahti <antonlahti@gmail.com>
 Benny Siegert <bsiegert@gmail.com>
 Bruno Bigras <bigras.bruno@gmail.com>
+Carlos Cobo <toqueteos@gmail.com>
 Cary Cherng <ccherng@gmail.com>
 Hill <zhubicen@gmail.com>
+Joseph Watson <jtwatson@linux-consulting.us>
 Kevin Pors <krpors@gmail.com>
 mycaosf <mycaosf@gmail.com>
 wsf01 <wf1337@sina.com>
-Carlos Cobo <toqueteos@gmail.com>

--- a/advapi32.go
+++ b/advapi32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/combobox.go
+++ b/combobox.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 // ComboBox return values

--- a/comctl32.go
+++ b/comctl32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/comdlg32.go
+++ b/comdlg32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/datetimepicker.go
+++ b/datetimepicker.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 const DTM_FIRST = 0x1000

--- a/edit.go
+++ b/edit.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 // Edit styles

--- a/gdi32.go
+++ b/gdi32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/gdiplus.go
+++ b/gdiplus.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/header.go
+++ b/header.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 const (

--- a/kernel32.go
+++ b/kernel32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/listbox.go
+++ b/listbox.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 // ListBox style

--- a/listview.go
+++ b/listview.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 const (

--- a/menu.go
+++ b/menu.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 // Constants for MENUITEMINFO.fMask

--- a/nonwin.go
+++ b/nonwin.go
@@ -1,0 +1,7 @@
+// Copyright 2010 The win Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !windows
+
+package win

--- a/nonwin.go
+++ b/nonwin.go
@@ -1,7 +1,0 @@
-// Copyright 2010 The win Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-// +build !windows
-
-package win

--- a/ole32.go
+++ b/ole32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/oleaut32.go
+++ b/oleaut32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/oleaut32_amd64.go
+++ b/oleaut32_amd64.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 type VAR_BSTR struct {

--- a/opengl32.go
+++ b/opengl32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/pdh.go
+++ b/pdh.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/shdocvw.go
+++ b/shdocvw.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/shell32.go
+++ b/shell32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/shobj.go
+++ b/shobj.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/shobj_amd64.go
+++ b/shobj_amd64.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/statusbar.go
+++ b/statusbar.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 // Styles

--- a/tab.go
+++ b/tab.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 const TCM_FIRST = 0x1300

--- a/toolbar.go
+++ b/toolbar.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 // ToolBar messages

--- a/tooltip.go
+++ b/tooltip.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/treeview.go
+++ b/treeview.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 // TreeView styles

--- a/updown.go
+++ b/updown.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 const UDN_FIRST = ^uint32(720)

--- a/user32.go
+++ b/user32.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/uxtheme.go
+++ b/uxtheme.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/win.go
+++ b/win.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (

--- a/winspool.go
+++ b/winspool.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build windows
+
 package win
 
 import (


### PR DESCRIPTION
Add build tags to allow this library to be included in a cross platform program.  This allows for several things:

- Develop on something other then a windows box, and cross compile the program to target windows.
- Develop a program that will run on the command line for any OS, but also have a gui when run on windows.
- Use the walk library for the windows gui, and some other library for a gui on other platforms.