### PR TITLE
Support for custom balloon icon

### DIFF
--- a/kernel32.go
+++ b/kernel32.go
@@ -141,7 +141,6 @@ func init() {
 	mulDiv = MustGetProcAddress(libkernel32, "MulDiv")
 	setLastError = MustGetProcAddress(libkernel32, "SetLastError")
 	systemTimeToFileTime = MustGetProcAddress(libkernel32, "SystemTimeToFileTime")
-
 }
 
 func CloseHandle(hObject HANDLE) bool {
@@ -264,12 +263,12 @@ func GetThreadUILanguage() LANGID {
 	return LANGID(ret)
 }
 
-func GetVersion() int64 {
+func GetVersion() uint32 {
 	ret, _, _ := syscall.Syscall(getVersion, 0,
 		0,
 		0,
 		0)
-	return int64(ret)
+	return uint32(ret)
 }
 
 func GlobalAlloc(uFlags uint32, dwBytes uintptr) HGLOBAL {

--- a/shell32.go
+++ b/shell32.go
@@ -113,7 +113,8 @@ const (
 	NIIF_NOSOUND = 0x00000010
 )
 
-const NOTIFYICON_VERSION = 3
+const NOTIFYICON_VERSION_XP uint32 = 0x3
+const NOTIFYICON_VERSION_VISTA uint32 = 0x4
 
 // SHGetFileInfo flags
 const (
@@ -152,6 +153,11 @@ type NOTIFYICONDATA struct {
 	SzInfoTitle      [64]uint16
 	DwInfoFlags      uint32
 	GuidItem         syscall.GUID
+	hBalloonIcon     HICON
+}
+
+func (nid *NOTIFYICONDATA) Set_hBalloonIcon(icon HICON) {
+	nid.hBalloonIcon = icon
 }
 
 type SHFILEINFO struct {


### PR DESCRIPTION
Changed NOTIFYICON_VERSION to NOTIFYICON_VERSION_XP and added NOTIFYCON_VERSION_VISTA, added hBalloonIcon to NOTIFYICONDATA for custom balloon icon, changed return type from GetVersion to uint32 (in win docs it its DWORD and DWORD is uint32), added Set_hBalloonIcon to NOTIFYICONDATA.

Needed by the following commit (also pull request): https://github.com/lxn/walk/pull/232/commits/f34c68611388e0770c4b8b9776b35f98c4c4d05b