### PR TITLE
add BCM_SETSHIELD

### DIFF
--- a/comctl32.go
+++ b/comctl32.go
@@ -25,6 +25,7 @@ const (
 	BCM_SETNOTE          = BCM_FIRST + 0x0009
 	BCM_GETNOTE          = BCM_FIRST + 0x000A
 	BCM_GETNOTELENGTH    = BCM_FIRST + 0x000B
+	BCM_SETSHIELD        = BCM_FIRST + 0x000C
 )
 
 const (


### PR DESCRIPTION
Can be used as follows to show the UAC shield on buttons which require elevated privileges:

```golang
pushButton.SendMessage(win.BCM_SETSHIELD, 0, 1)
```