### PR TITLE
Fix GPTR flag to correct value

### DIFF
--- a/kernel32.go
+++ b/kernel32.go
@@ -29,7 +29,7 @@ const (
 	GMEM_FIXED    = 0x0000
 	GMEM_MOVEABLE = 0x0002
 	GMEM_ZEROINIT = 0x0040
-	GPTR          = 0x004
+	GPTR          = GMEM_FIXED | GMEM_ZEROINIT
 )
 
 // Predefined locale ids


### PR DESCRIPTION
GPTR previously had an incorrect value, resulting in incorrect handles being returned from GlobalAlloc. This commit fixes it to match what is defined in WinBase.h.