### PR TITLE
Proper custom color handling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,4 @@ mycaosf <mycaosf@gmail.com>
 ryujimiya <ryujimiya236@gmail.com>
 wsf01 <wf1337@sina.com>
 gonutz
+Cory Redmond <ace@ac3-servers.eu>

--- a/comdlg32.go
+++ b/comdlg32.go
@@ -46,7 +46,7 @@ type CHOOSECOLOR struct {
 	HwndOwner      HWND
 	HInstance      HWND
 	RgbResult      COLORREF
-	LpCustColors   *COLORREF
+	LpCustColors   *[16]COLORREF
 	Flags          uint32
 	LCustData      uintptr
 	LpfnHook       uintptr


### PR DESCRIPTION
https://docs.microsoft.com/en-gb/windows/desktop/api/commdlg/ns-commdlg-tagchoosecolora

The Microsoft documentation says that type `LpCustColors` is as follows:
>A pointer to an array of 16 values that contain red, green, blue (RGB) values for the custom color boxes in the dialog box. If the user modifies these colors, the system updates the array with the new RGB values.