### PR TITLE
Safely load DLLs

### DIFF
--- a/advapi32.go
+++ b/advapi32.go
@@ -7,6 +7,7 @@
 package win
 
 import (
+	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
 )
@@ -55,30 +56,30 @@ const (
 
 var (
 	// Library
-	libadvapi32 uintptr
+	libadvapi32 *windows.LazyDLL
 
 	// Functions
-	regCloseKey     uintptr
-	regOpenKeyEx    uintptr
-	regQueryValueEx uintptr
-	regEnumValue    uintptr
-	regSetValueEx   uintptr
+	regCloseKey     *windows.LazyProc
+	regOpenKeyEx    *windows.LazyProc
+	regQueryValueEx *windows.LazyProc
+	regEnumValue    *windows.LazyProc
+	regSetValueEx   *windows.LazyProc
 )
 
 func init() {
 	// Library
-	libadvapi32 = MustLoadLibrary("advapi32.dll")
+	libadvapi32 = windows.NewLazySystemDLL("advapi32.dll")
 
 	// Functions
-	regCloseKey = MustGetProcAddress(libadvapi32, "RegCloseKey")
-	regOpenKeyEx = MustGetProcAddress(libadvapi32, "RegOpenKeyExW")
-	regQueryValueEx = MustGetProcAddress(libadvapi32, "RegQueryValueExW")
-	regEnumValue = MustGetProcAddress(libadvapi32, "RegEnumValueW")
-	regSetValueEx = MustGetProcAddress(libadvapi32, "RegSetValueExW")
+	regCloseKey = libadvapi32.NewProc("RegCloseKey")
+	regOpenKeyEx = libadvapi32.NewProc("RegOpenKeyExW")
+	regQueryValueEx = libadvapi32.NewProc("RegQueryValueExW")
+	regEnumValue = libadvapi32.NewProc("RegEnumValueW")
+	regSetValueEx = libadvapi32.NewProc("RegSetValueExW")
 }
 
 func RegCloseKey(hKey HKEY) int32 {
-	ret, _, _ := syscall.Syscall(regCloseKey, 1,
+	ret, _, _ := syscall.Syscall(regCloseKey.Addr(), 1,
 		uintptr(hKey),
 		0,
 		0)
@@ -87,7 +88,7 @@ func RegCloseKey(hKey HKEY) int32 {
 }
 
 func RegOpenKeyEx(hKey HKEY, lpSubKey *uint16, ulOptions uint32, samDesired REGSAM, phkResult *HKEY) int32 {
-	ret, _, _ := syscall.Syscall6(regOpenKeyEx, 5,
+	ret, _, _ := syscall.Syscall6(regOpenKeyEx.Addr(), 5,
 		uintptr(hKey),
 		uintptr(unsafe.Pointer(lpSubKey)),
 		uintptr(ulOptions),
@@ -99,7 +100,7 @@ func RegOpenKeyEx(hKey HKEY, lpSubKey *uint16, ulOptions uint32, samDesired REGS
 }
 
 func RegQueryValueEx(hKey HKEY, lpValueName *uint16, lpReserved, lpType *uint32, lpData *byte, lpcbData *uint32) int32 {
-	ret, _, _ := syscall.Syscall6(regQueryValueEx, 6,
+	ret, _, _ := syscall.Syscall6(regQueryValueEx.Addr(), 6,
 		uintptr(hKey),
 		uintptr(unsafe.Pointer(lpValueName)),
 		uintptr(unsafe.Pointer(lpReserved)),
@@ -111,7 +112,7 @@ func RegQueryValueEx(hKey HKEY, lpValueName *uint16, lpReserved, lpType *uint32,
 }
 
 func RegEnumValue(hKey HKEY, index uint32, lpValueName *uint16, lpcchValueName *uint32, lpReserved, lpType *uint32, lpData *byte, lpcbData *uint32) int32 {
-	ret, _, _ := syscall.Syscall9(regEnumValue, 8,
+	ret, _, _ := syscall.Syscall9(regEnumValue.Addr(), 8,
 		uintptr(hKey),
 		uintptr(index),
 		uintptr(unsafe.Pointer(lpValueName)),
@@ -125,7 +126,7 @@ func RegEnumValue(hKey HKEY, index uint32, lpValueName *uint16, lpcchValueName *
 }
 
 func RegSetValueEx(hKey HKEY, lpValueName *uint16, lpReserved, lpDataType uint64, lpData *byte, cbData uint32) int32 {
-	ret, _, _ := syscall.Syscall6(regSetValueEx, 6,
+	ret, _, _ := syscall.Syscall6(regSetValueEx.Addr(), 6,
 		uintptr(hKey),
 		uintptr(unsafe.Pointer(lpValueName)),
 		uintptr(lpReserved),

--- a/comdlg32.go
+++ b/comdlg32.go
@@ -7,6 +7,7 @@
 package win
 
 import (
+	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
 )
@@ -231,30 +232,30 @@ type PRINTDLGEX struct {
 
 var (
 	// Library
-	libcomdlg32 uintptr
+	libcomdlg32 *windows.LazyDLL
 
 	// Functions
-	chooseColor          uintptr
-	commDlgExtendedError uintptr
-	getOpenFileName      uintptr
-	getSaveFileName      uintptr
-	printDlgEx           uintptr
+	chooseColor          *windows.LazyProc
+	commDlgExtendedError *windows.LazyProc
+	getOpenFileName      *windows.LazyProc
+	getSaveFileName      *windows.LazyProc
+	printDlgEx           *windows.LazyProc
 )
 
 func init() {
 	// Library
-	libcomdlg32 = MustLoadLibrary("comdlg32.dll")
+	libcomdlg32 = windows.NewLazySystemDLL("comdlg32.dll")
 
 	// Functions
-	chooseColor = MustGetProcAddress(libcomdlg32, "ChooseColorW")
-	commDlgExtendedError = MustGetProcAddress(libcomdlg32, "CommDlgExtendedError")
-	getOpenFileName = MustGetProcAddress(libcomdlg32, "GetOpenFileNameW")
-	getSaveFileName = MustGetProcAddress(libcomdlg32, "GetSaveFileNameW")
-	printDlgEx = MustGetProcAddress(libcomdlg32, "PrintDlgExW")
+	chooseColor = libcomdlg32.NewProc("ChooseColorW")
+	commDlgExtendedError = libcomdlg32.NewProc("CommDlgExtendedError")
+	getOpenFileName = libcomdlg32.NewProc("GetOpenFileNameW")
+	getSaveFileName = libcomdlg32.NewProc("GetSaveFileNameW")
+	printDlgEx = libcomdlg32.NewProc("PrintDlgExW")
 }
 
 func ChooseColor(lpcc *CHOOSECOLOR) bool {
-	ret, _, _ := syscall.Syscall(chooseColor, 1,
+	ret, _, _ := syscall.Syscall(chooseColor.Addr(), 1,
 		uintptr(unsafe.Pointer(lpcc)),
 		0,
 		0)
@@ -263,7 +264,7 @@ func ChooseColor(lpcc *CHOOSECOLOR) bool {
 }
 
 func CommDlgExtendedError() uint32 {
-	ret, _, _ := syscall.Syscall(commDlgExtendedError, 0,
+	ret, _, _ := syscall.Syscall(commDlgExtendedError.Addr(), 0,
 		0,
 		0,
 		0)
@@ -272,7 +273,7 @@ func CommDlgExtendedError() uint32 {
 }
 
 func GetOpenFileName(lpofn *OPENFILENAME) bool {
-	ret, _, _ := syscall.Syscall(getOpenFileName, 1,
+	ret, _, _ := syscall.Syscall(getOpenFileName.Addr(), 1,
 		uintptr(unsafe.Pointer(lpofn)),
 		0,
 		0)
@@ -281,7 +282,7 @@ func GetOpenFileName(lpofn *OPENFILENAME) bool {
 }
 
 func GetSaveFileName(lpofn *OPENFILENAME) bool {
-	ret, _, _ := syscall.Syscall(getSaveFileName, 1,
+	ret, _, _ := syscall.Syscall(getSaveFileName.Addr(), 1,
 		uintptr(unsafe.Pointer(lpofn)),
 		0,
 		0)
@@ -290,7 +291,7 @@ func GetSaveFileName(lpofn *OPENFILENAME) bool {
 }
 
 func PrintDlgEx(lppd *PRINTDLGEX) HRESULT {
-	ret, _, _ := syscall.Syscall(printDlgEx, 1,
+	ret, _, _ := syscall.Syscall(printDlgEx.Addr(), 1,
 		uintptr(unsafe.Pointer(lppd)),
 		0,
 		0)

--- a/gdi32.go
+++ b/gdi32.go
@@ -7,6 +7,7 @@
 package win
 
 import (
+	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
 )
@@ -1028,165 +1029,165 @@ type BLENDFUNCTION struct {
 
 var (
 	// Library
-	libgdi32   uintptr
-	libmsimg32 uintptr
+	libgdi32   *windows.LazyDLL
+	libmsimg32 *windows.LazyDLL
 
 	// Functions
-	abortDoc               uintptr
-	addFontResourceEx      uintptr
-	alphaBlend             uintptr
-	bitBlt                 uintptr
-	choosePixelFormat      uintptr
-	closeEnhMetaFile       uintptr
-	combineRgn             uintptr
-	copyEnhMetaFile        uintptr
-	createBitmap           uintptr
-	createCompatibleBitmap uintptr
-	createBrushIndirect    uintptr
-	createCompatibleDC     uintptr
-	createDC               uintptr
-	createDIBSection       uintptr
-	createFontIndirect     uintptr
-	createEnhMetaFile      uintptr
-	createIC               uintptr
-	createPatternBrush     uintptr
-	createRectRgn          uintptr
-	deleteDC               uintptr
-	deleteEnhMetaFile      uintptr
-	deleteObject           uintptr
-	ellipse                uintptr
-	endDoc                 uintptr
-	endPage                uintptr
-	excludeClipRect        uintptr
-	extCreatePen           uintptr
-	fillRgn                uintptr
-	gdiFlush               uintptr
-	getBkColor             uintptr
-	getDeviceCaps          uintptr
-	getDIBits              uintptr
-	getEnhMetaFile         uintptr
-	getEnhMetaFileHeader   uintptr
-	getObject              uintptr
-	getPixel               uintptr
-	getRgnBox              uintptr
-	getStockObject         uintptr
-	getTextColor           uintptr
-	getTextExtentExPoint   uintptr
-	getTextExtentPoint32   uintptr
-	getTextMetrics         uintptr
-	getViewportOrgEx       uintptr
-	gradientFill           uintptr
-	intersectClipRect      uintptr
-	lineTo                 uintptr
-	moveToEx               uintptr
-	playEnhMetaFile        uintptr
-	polyline               uintptr
-	rectangle              uintptr
-	removeFontResourceEx   uintptr
-	resetDC                uintptr
-	restoreDC              uintptr
-	roundRect              uintptr
-	selectObject           uintptr
-	setBkColor             uintptr
-	setBkMode              uintptr
-	setBrushOrgEx          uintptr
-	setDIBits              uintptr
-	setPixel               uintptr
-	setPixelFormat         uintptr
-	setStretchBltMode      uintptr
-	setTextColor           uintptr
-	setViewportOrgEx       uintptr
-	saveDC                 uintptr
-	startDoc               uintptr
-	startPage              uintptr
-	stretchBlt             uintptr
-	swapBuffers            uintptr
-	textOut                uintptr
-	transparentBlt         uintptr
+	abortDoc               *windows.LazyProc
+	addFontResourceEx      *windows.LazyProc
+	alphaBlend             *windows.LazyProc
+	bitBlt                 *windows.LazyProc
+	choosePixelFormat      *windows.LazyProc
+	closeEnhMetaFile       *windows.LazyProc
+	combineRgn             *windows.LazyProc
+	copyEnhMetaFile        *windows.LazyProc
+	createBitmap           *windows.LazyProc
+	createCompatibleBitmap *windows.LazyProc
+	createBrushIndirect    *windows.LazyProc
+	createCompatibleDC     *windows.LazyProc
+	createDC               *windows.LazyProc
+	createDIBSection       *windows.LazyProc
+	createFontIndirect     *windows.LazyProc
+	createEnhMetaFile      *windows.LazyProc
+	createIC               *windows.LazyProc
+	createPatternBrush     *windows.LazyProc
+	createRectRgn          *windows.LazyProc
+	deleteDC               *windows.LazyProc
+	deleteEnhMetaFile      *windows.LazyProc
+	deleteObject           *windows.LazyProc
+	ellipse                *windows.LazyProc
+	endDoc                 *windows.LazyProc
+	endPage                *windows.LazyProc
+	excludeClipRect        *windows.LazyProc
+	extCreatePen           *windows.LazyProc
+	fillRgn                *windows.LazyProc
+	gdiFlush               *windows.LazyProc
+	getBkColor             *windows.LazyProc
+	getDeviceCaps          *windows.LazyProc
+	getDIBits              *windows.LazyProc
+	getEnhMetaFile         *windows.LazyProc
+	getEnhMetaFileHeader   *windows.LazyProc
+	getObject              *windows.LazyProc
+	getPixel               *windows.LazyProc
+	getRgnBox              *windows.LazyProc
+	getStockObject         *windows.LazyProc
+	getTextColor           *windows.LazyProc
+	getTextExtentExPoint   *windows.LazyProc
+	getTextExtentPoint32   *windows.LazyProc
+	getTextMetrics         *windows.LazyProc
+	getViewportOrgEx       *windows.LazyProc
+	gradientFill           *windows.LazyProc
+	intersectClipRect      *windows.LazyProc
+	lineTo                 *windows.LazyProc
+	moveToEx               *windows.LazyProc
+	playEnhMetaFile        *windows.LazyProc
+	polyline               *windows.LazyProc
+	rectangle              *windows.LazyProc
+	removeFontResourceEx   *windows.LazyProc
+	resetDC                *windows.LazyProc
+	restoreDC              *windows.LazyProc
+	roundRect              *windows.LazyProc
+	selectObject           *windows.LazyProc
+	setBkColor             *windows.LazyProc
+	setBkMode              *windows.LazyProc
+	setBrushOrgEx          *windows.LazyProc
+	setDIBits              *windows.LazyProc
+	setPixel               *windows.LazyProc
+	setPixelFormat         *windows.LazyProc
+	setStretchBltMode      *windows.LazyProc
+	setTextColor           *windows.LazyProc
+	setViewportOrgEx       *windows.LazyProc
+	saveDC                 *windows.LazyProc
+	startDoc               *windows.LazyProc
+	startPage              *windows.LazyProc
+	stretchBlt             *windows.LazyProc
+	swapBuffers            *windows.LazyProc
+	textOut                *windows.LazyProc
+	transparentBlt         *windows.LazyProc
 )
 
 func init() {
 	// Library
-	libgdi32 = MustLoadLibrary("gdi32.dll")
-	libmsimg32 = MustLoadLibrary("msimg32.dll")
+	libgdi32 = windows.NewLazySystemDLL("gdi32.dll")
+	libmsimg32 = windows.NewLazySystemDLL("msimg32.dll")
 
 	// Functions
-	abortDoc = MustGetProcAddress(libgdi32, "AbortDoc")
-	addFontResourceEx = MustGetProcAddress(libgdi32, "AddFontResourceExW")
-	bitBlt = MustGetProcAddress(libgdi32, "BitBlt")
-	choosePixelFormat = MustGetProcAddress(libgdi32, "ChoosePixelFormat")
-	closeEnhMetaFile = MustGetProcAddress(libgdi32, "CloseEnhMetaFile")
-	combineRgn = MustGetProcAddress(libgdi32, "CombineRgn")
-	copyEnhMetaFile = MustGetProcAddress(libgdi32, "CopyEnhMetaFileW")
-	createBitmap = MustGetProcAddress(libgdi32, "CreateBitmap")
-	createCompatibleBitmap = MustGetProcAddress(libgdi32, "CreateCompatibleBitmap")
-	createBrushIndirect = MustGetProcAddress(libgdi32, "CreateBrushIndirect")
-	createCompatibleDC = MustGetProcAddress(libgdi32, "CreateCompatibleDC")
-	createDC = MustGetProcAddress(libgdi32, "CreateDCW")
-	createDIBSection = MustGetProcAddress(libgdi32, "CreateDIBSection")
-	createEnhMetaFile = MustGetProcAddress(libgdi32, "CreateEnhMetaFileW")
-	createFontIndirect = MustGetProcAddress(libgdi32, "CreateFontIndirectW")
-	createIC = MustGetProcAddress(libgdi32, "CreateICW")
-	createPatternBrush = MustGetProcAddress(libgdi32, "CreatePatternBrush")
-	createRectRgn = MustGetProcAddress(libgdi32, "CreateRectRgn")
-	deleteDC = MustGetProcAddress(libgdi32, "DeleteDC")
-	deleteEnhMetaFile = MustGetProcAddress(libgdi32, "DeleteEnhMetaFile")
-	deleteObject = MustGetProcAddress(libgdi32, "DeleteObject")
-	ellipse = MustGetProcAddress(libgdi32, "Ellipse")
-	endDoc = MustGetProcAddress(libgdi32, "EndDoc")
-	endPage = MustGetProcAddress(libgdi32, "EndPage")
-	excludeClipRect = MustGetProcAddress(libgdi32, "ExcludeClipRect")
-	extCreatePen = MustGetProcAddress(libgdi32, "ExtCreatePen")
-	fillRgn = MustGetProcAddress(libgdi32, "FillRgn")
-	gdiFlush = MustGetProcAddress(libgdi32, "GdiFlush")
-	getBkColor = MustGetProcAddress(libgdi32, "GetBkColor")
-	getDeviceCaps = MustGetProcAddress(libgdi32, "GetDeviceCaps")
-	getDIBits = MustGetProcAddress(libgdi32, "GetDIBits")
-	getEnhMetaFile = MustGetProcAddress(libgdi32, "GetEnhMetaFileW")
-	getEnhMetaFileHeader = MustGetProcAddress(libgdi32, "GetEnhMetaFileHeader")
-	getObject = MustGetProcAddress(libgdi32, "GetObjectW")
-	getPixel = MustGetProcAddress(libgdi32, "GetPixel")
-	getRgnBox = MustGetProcAddress(libgdi32, "GetRgnBox")
-	getStockObject = MustGetProcAddress(libgdi32, "GetStockObject")
-	getTextColor = MustGetProcAddress(libgdi32, "GetTextColor")
-	getTextExtentExPoint = MustGetProcAddress(libgdi32, "GetTextExtentExPointW")
-	getTextExtentPoint32 = MustGetProcAddress(libgdi32, "GetTextExtentPoint32W")
-	getTextMetrics = MustGetProcAddress(libgdi32, "GetTextMetricsW")
-	getViewportOrgEx = MustGetProcAddress(libgdi32, "GetViewportOrgEx")
-	intersectClipRect = MustGetProcAddress(libgdi32, "IntersectClipRect")
-	lineTo = MustGetProcAddress(libgdi32, "LineTo")
-	moveToEx = MustGetProcAddress(libgdi32, "MoveToEx")
-	playEnhMetaFile = MustGetProcAddress(libgdi32, "PlayEnhMetaFile")
-	polyline = MustGetProcAddress(libgdi32, "Polyline")
-	rectangle = MustGetProcAddress(libgdi32, "Rectangle")
-	removeFontResourceEx = MustGetProcAddress(libgdi32, "RemoveFontResourceExW")
-	resetDC = MustGetProcAddress(libgdi32, "ResetDCW")
-	restoreDC = MustGetProcAddress(libgdi32, "RestoreDC")
-	roundRect = MustGetProcAddress(libgdi32, "RoundRect")
-	saveDC = MustGetProcAddress(libgdi32, "SaveDC")
-	selectObject = MustGetProcAddress(libgdi32, "SelectObject")
-	setBkColor = MustGetProcAddress(libgdi32, "SetBkColor")
-	setBkMode = MustGetProcAddress(libgdi32, "SetBkMode")
-	setBrushOrgEx = MustGetProcAddress(libgdi32, "SetBrushOrgEx")
-	setDIBits = MustGetProcAddress(libgdi32, "SetDIBits")
-	setPixel = MustGetProcAddress(libgdi32, "SetPixel")
-	setPixelFormat = MustGetProcAddress(libgdi32, "SetPixelFormat")
-	setStretchBltMode = MustGetProcAddress(libgdi32, "SetStretchBltMode")
-	setTextColor = MustGetProcAddress(libgdi32, "SetTextColor")
-	setViewportOrgEx = MustGetProcAddress(libgdi32, "SetViewportOrgEx")
-	startDoc = MustGetProcAddress(libgdi32, "StartDocW")
-	startPage = MustGetProcAddress(libgdi32, "StartPage")
-	stretchBlt = MustGetProcAddress(libgdi32, "StretchBlt")
-	swapBuffers = MustGetProcAddress(libgdi32, "SwapBuffers")
-	textOut = MustGetProcAddress(libgdi32, "TextOutW")
+	abortDoc = libgdi32.NewProc("AbortDoc")
+	addFontResourceEx = libgdi32.NewProc("AddFontResourceExW")
+	bitBlt = libgdi32.NewProc("BitBlt")
+	choosePixelFormat = libgdi32.NewProc("ChoosePixelFormat")
+	closeEnhMetaFile = libgdi32.NewProc("CloseEnhMetaFile")
+	combineRgn = libgdi32.NewProc("CombineRgn")
+	copyEnhMetaFile = libgdi32.NewProc("CopyEnhMetaFileW")
+	createBitmap = libgdi32.NewProc("CreateBitmap")
+	createCompatibleBitmap = libgdi32.NewProc("CreateCompatibleBitmap")
+	createBrushIndirect = libgdi32.NewProc("CreateBrushIndirect")
+	createCompatibleDC = libgdi32.NewProc("CreateCompatibleDC")
+	createDC = libgdi32.NewProc("CreateDCW")
+	createDIBSection = libgdi32.NewProc("CreateDIBSection")
+	createEnhMetaFile = libgdi32.NewProc("CreateEnhMetaFileW")
+	createFontIndirect = libgdi32.NewProc("CreateFontIndirectW")
+	createIC = libgdi32.NewProc("CreateICW")
+	createPatternBrush = libgdi32.NewProc("CreatePatternBrush")
+	createRectRgn = libgdi32.NewProc("CreateRectRgn")
+	deleteDC = libgdi32.NewProc("DeleteDC")
+	deleteEnhMetaFile = libgdi32.NewProc("DeleteEnhMetaFile")
+	deleteObject = libgdi32.NewProc("DeleteObject")
+	ellipse = libgdi32.NewProc("Ellipse")
+	endDoc = libgdi32.NewProc("EndDoc")
+	endPage = libgdi32.NewProc("EndPage")
+	excludeClipRect = libgdi32.NewProc("ExcludeClipRect")
+	extCreatePen = libgdi32.NewProc("ExtCreatePen")
+	fillRgn = libgdi32.NewProc("FillRgn")
+	gdiFlush = libgdi32.NewProc("GdiFlush")
+	getBkColor = libgdi32.NewProc("GetBkColor")
+	getDeviceCaps = libgdi32.NewProc("GetDeviceCaps")
+	getDIBits = libgdi32.NewProc("GetDIBits")
+	getEnhMetaFile = libgdi32.NewProc("GetEnhMetaFileW")
+	getEnhMetaFileHeader = libgdi32.NewProc("GetEnhMetaFileHeader")
+	getObject = libgdi32.NewProc("GetObjectW")
+	getPixel = libgdi32.NewProc("GetPixel")
+	getRgnBox = libgdi32.NewProc("GetRgnBox")
+	getStockObject = libgdi32.NewProc("GetStockObject")
+	getTextColor = libgdi32.NewProc("GetTextColor")
+	getTextExtentExPoint = libgdi32.NewProc("GetTextExtentExPointW")
+	getTextExtentPoint32 = libgdi32.NewProc("GetTextExtentPoint32W")
+	getTextMetrics = libgdi32.NewProc("GetTextMetricsW")
+	getViewportOrgEx = libgdi32.NewProc("GetViewportOrgEx")
+	intersectClipRect = libgdi32.NewProc("IntersectClipRect")
+	lineTo = libgdi32.NewProc("LineTo")
+	moveToEx = libgdi32.NewProc("MoveToEx")
+	playEnhMetaFile = libgdi32.NewProc("PlayEnhMetaFile")
+	polyline = libgdi32.NewProc("Polyline")
+	rectangle = libgdi32.NewProc("Rectangle")
+	removeFontResourceEx = libgdi32.NewProc("RemoveFontResourceExW")
+	resetDC = libgdi32.NewProc("ResetDCW")
+	restoreDC = libgdi32.NewProc("RestoreDC")
+	roundRect = libgdi32.NewProc("RoundRect")
+	saveDC = libgdi32.NewProc("SaveDC")
+	selectObject = libgdi32.NewProc("SelectObject")
+	setBkColor = libgdi32.NewProc("SetBkColor")
+	setBkMode = libgdi32.NewProc("SetBkMode")
+	setBrushOrgEx = libgdi32.NewProc("SetBrushOrgEx")
+	setDIBits = libgdi32.NewProc("SetDIBits")
+	setPixel = libgdi32.NewProc("SetPixel")
+	setPixelFormat = libgdi32.NewProc("SetPixelFormat")
+	setStretchBltMode = libgdi32.NewProc("SetStretchBltMode")
+	setTextColor = libgdi32.NewProc("SetTextColor")
+	setViewportOrgEx = libgdi32.NewProc("SetViewportOrgEx")
+	startDoc = libgdi32.NewProc("StartDocW")
+	startPage = libgdi32.NewProc("StartPage")
+	stretchBlt = libgdi32.NewProc("StretchBlt")
+	swapBuffers = libgdi32.NewProc("SwapBuffers")
+	textOut = libgdi32.NewProc("TextOutW")
 
-	alphaBlend = MustGetProcAddress(libmsimg32, "AlphaBlend")
-	gradientFill = MustGetProcAddress(libmsimg32, "GradientFill")
-	transparentBlt = MustGetProcAddress(libmsimg32, "TransparentBlt")
+	alphaBlend = libmsimg32.NewProc("AlphaBlend")
+	gradientFill = libmsimg32.NewProc("GradientFill")
+	transparentBlt = libmsimg32.NewProc("TransparentBlt")
 }
 
 func AbortDoc(hdc HDC) int32 {
-	ret, _, _ := syscall.Syscall(abortDoc, 1,
+	ret, _, _ := syscall.Syscall(abortDoc.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1195,7 +1196,7 @@ func AbortDoc(hdc HDC) int32 {
 }
 
 func AddFontResourceEx(lpszFilename *uint16, fl uint32, pdv unsafe.Pointer) int32 {
-	ret, _, _ := syscall.Syscall(addFontResourceEx, 3,
+	ret, _, _ := syscall.Syscall(addFontResourceEx.Addr(), 3,
 		uintptr(unsafe.Pointer(lpszFilename)),
 		uintptr(fl),
 		uintptr(pdv))
@@ -1204,7 +1205,7 @@ func AddFontResourceEx(lpszFilename *uint16, fl uint32, pdv unsafe.Pointer) int3
 }
 
 func AlphaBlend(hdcDest HDC, nXOriginDest, nYOriginDest, nWidthDest, nHeightDest int32, hdcSrc HDC, nXOriginSrc, nYOriginSrc, nWidthSrc, nHeightSrc int32, ftn BLENDFUNCTION) bool {
-	ret, _, _ := syscall.Syscall12(alphaBlend, 11,
+	ret, _, _ := syscall.Syscall12(alphaBlend.Addr(), 11,
 		uintptr(hdcDest),
 		uintptr(nXOriginDest),
 		uintptr(nYOriginDest),
@@ -1222,7 +1223,7 @@ func AlphaBlend(hdcDest HDC, nXOriginDest, nYOriginDest, nWidthDest, nHeightDest
 }
 
 func BitBlt(hdcDest HDC, nXDest, nYDest, nWidth, nHeight int32, hdcSrc HDC, nXSrc, nYSrc int32, dwRop uint32) bool {
-	ret, _, _ := syscall.Syscall9(bitBlt, 9,
+	ret, _, _ := syscall.Syscall9(bitBlt.Addr(), 9,
 		uintptr(hdcDest),
 		uintptr(nXDest),
 		uintptr(nYDest),
@@ -1237,7 +1238,7 @@ func BitBlt(hdcDest HDC, nXDest, nYDest, nWidth, nHeight int32, hdcSrc HDC, nXSr
 }
 
 func ChoosePixelFormat(hdc HDC, ppfd *PIXELFORMATDESCRIPTOR) int32 {
-	ret, _, _ := syscall.Syscall(choosePixelFormat, 2,
+	ret, _, _ := syscall.Syscall(choosePixelFormat.Addr(), 2,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(ppfd)),
 		0)
@@ -1246,7 +1247,7 @@ func ChoosePixelFormat(hdc HDC, ppfd *PIXELFORMATDESCRIPTOR) int32 {
 }
 
 func CloseEnhMetaFile(hdc HDC) HENHMETAFILE {
-	ret, _, _ := syscall.Syscall(closeEnhMetaFile, 1,
+	ret, _, _ := syscall.Syscall(closeEnhMetaFile.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1255,7 +1256,7 @@ func CloseEnhMetaFile(hdc HDC) HENHMETAFILE {
 }
 
 func CombineRgn(hrgnDest, hrgnSrc1, hrgnSrc2 HRGN, fnCombineMode int32) int32 {
-	ret, _, _ := syscall.Syscall6(combineRgn, 4,
+	ret, _, _ := syscall.Syscall6(combineRgn.Addr(), 4,
 		uintptr(hrgnDest),
 		uintptr(hrgnSrc1),
 		uintptr(hrgnSrc2),
@@ -1267,7 +1268,7 @@ func CombineRgn(hrgnDest, hrgnSrc1, hrgnSrc2 HRGN, fnCombineMode int32) int32 {
 }
 
 func CopyEnhMetaFile(hemfSrc HENHMETAFILE, lpszFile *uint16) HENHMETAFILE {
-	ret, _, _ := syscall.Syscall(copyEnhMetaFile, 2,
+	ret, _, _ := syscall.Syscall(copyEnhMetaFile.Addr(), 2,
 		uintptr(hemfSrc),
 		uintptr(unsafe.Pointer(lpszFile)),
 		0)
@@ -1276,7 +1277,7 @@ func CopyEnhMetaFile(hemfSrc HENHMETAFILE, lpszFile *uint16) HENHMETAFILE {
 }
 
 func CreateBitmap(nWidth, nHeight int32, cPlanes, cBitsPerPel uint32, lpvBits unsafe.Pointer) HBITMAP {
-	ret, _, _ := syscall.Syscall6(createBitmap, 5,
+	ret, _, _ := syscall.Syscall6(createBitmap.Addr(), 5,
 		uintptr(nWidth),
 		uintptr(nHeight),
 		uintptr(cPlanes),
@@ -1288,7 +1289,7 @@ func CreateBitmap(nWidth, nHeight int32, cPlanes, cBitsPerPel uint32, lpvBits un
 }
 
 func CreateCompatibleBitmap(hdc HDC, nWidth, nHeight int32) HBITMAP {
-	ret, _, _ := syscall.Syscall(createCompatibleBitmap, 3,
+	ret, _, _ := syscall.Syscall(createCompatibleBitmap.Addr(), 3,
 		uintptr(hdc),
 		uintptr(nWidth),
 		uintptr(nHeight))
@@ -1297,7 +1298,7 @@ func CreateCompatibleBitmap(hdc HDC, nWidth, nHeight int32) HBITMAP {
 }
 
 func CreateBrushIndirect(lplb *LOGBRUSH) HBRUSH {
-	ret, _, _ := syscall.Syscall(createBrushIndirect, 1,
+	ret, _, _ := syscall.Syscall(createBrushIndirect.Addr(), 1,
 		uintptr(unsafe.Pointer(lplb)),
 		0,
 		0)
@@ -1306,7 +1307,7 @@ func CreateBrushIndirect(lplb *LOGBRUSH) HBRUSH {
 }
 
 func CreateCompatibleDC(hdc HDC) HDC {
-	ret, _, _ := syscall.Syscall(createCompatibleDC, 1,
+	ret, _, _ := syscall.Syscall(createCompatibleDC.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1315,7 +1316,7 @@ func CreateCompatibleDC(hdc HDC) HDC {
 }
 
 func CreateDC(lpszDriver, lpszDevice, lpszOutput *uint16, lpInitData *DEVMODE) HDC {
-	ret, _, _ := syscall.Syscall6(createDC, 4,
+	ret, _, _ := syscall.Syscall6(createDC.Addr(), 4,
 		uintptr(unsafe.Pointer(lpszDriver)),
 		uintptr(unsafe.Pointer(lpszDevice)),
 		uintptr(unsafe.Pointer(lpszOutput)),
@@ -1327,7 +1328,7 @@ func CreateDC(lpszDriver, lpszDevice, lpszOutput *uint16, lpInitData *DEVMODE) H
 }
 
 func CreateDIBSection(hdc HDC, pbmih *BITMAPINFOHEADER, iUsage uint32, ppvBits *unsafe.Pointer, hSection HANDLE, dwOffset uint32) HBITMAP {
-	ret, _, _ := syscall.Syscall6(createDIBSection, 6,
+	ret, _, _ := syscall.Syscall6(createDIBSection.Addr(), 6,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(pbmih)),
 		uintptr(iUsage),
@@ -1339,7 +1340,7 @@ func CreateDIBSection(hdc HDC, pbmih *BITMAPINFOHEADER, iUsage uint32, ppvBits *
 }
 
 func CreateEnhMetaFile(hdcRef HDC, lpFilename *uint16, lpRect *RECT, lpDescription *uint16) HDC {
-	ret, _, _ := syscall.Syscall6(createEnhMetaFile, 4,
+	ret, _, _ := syscall.Syscall6(createEnhMetaFile.Addr(), 4,
 		uintptr(hdcRef),
 		uintptr(unsafe.Pointer(lpFilename)),
 		uintptr(unsafe.Pointer(lpRect)),
@@ -1351,7 +1352,7 @@ func CreateEnhMetaFile(hdcRef HDC, lpFilename *uint16, lpRect *RECT, lpDescripti
 }
 
 func CreateFontIndirect(lplf *LOGFONT) HFONT {
-	ret, _, _ := syscall.Syscall(createFontIndirect, 1,
+	ret, _, _ := syscall.Syscall(createFontIndirect.Addr(), 1,
 		uintptr(unsafe.Pointer(lplf)),
 		0,
 		0)
@@ -1360,7 +1361,7 @@ func CreateFontIndirect(lplf *LOGFONT) HFONT {
 }
 
 func CreateIC(lpszDriver, lpszDevice, lpszOutput *uint16, lpdvmInit *DEVMODE) HDC {
-	ret, _, _ := syscall.Syscall6(createIC, 4,
+	ret, _, _ := syscall.Syscall6(createIC.Addr(), 4,
 		uintptr(unsafe.Pointer(lpszDriver)),
 		uintptr(unsafe.Pointer(lpszDevice)),
 		uintptr(unsafe.Pointer(lpszOutput)),
@@ -1372,7 +1373,7 @@ func CreateIC(lpszDriver, lpszDevice, lpszOutput *uint16, lpdvmInit *DEVMODE) HD
 }
 
 func CreatePatternBrush(hbmp HBITMAP) HBRUSH {
-	ret, _, _ := syscall.Syscall(createPatternBrush, 1,
+	ret, _, _ := syscall.Syscall(createPatternBrush.Addr(), 1,
 		uintptr(hbmp),
 		0,
 		0)
@@ -1381,7 +1382,7 @@ func CreatePatternBrush(hbmp HBITMAP) HBRUSH {
 }
 
 func CreateRectRgn(nLeftRect, nTopRect, nRightRect, nBottomRect int32) HRGN {
-	ret, _, _ := syscall.Syscall6(createRectRgn, 4,
+	ret, _, _ := syscall.Syscall6(createRectRgn.Addr(), 4,
 		uintptr(nLeftRect),
 		uintptr(nTopRect),
 		uintptr(nRightRect),
@@ -1393,7 +1394,7 @@ func CreateRectRgn(nLeftRect, nTopRect, nRightRect, nBottomRect int32) HRGN {
 }
 
 func DeleteDC(hdc HDC) bool {
-	ret, _, _ := syscall.Syscall(deleteDC, 1,
+	ret, _, _ := syscall.Syscall(deleteDC.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1402,7 +1403,7 @@ func DeleteDC(hdc HDC) bool {
 }
 
 func DeleteEnhMetaFile(hemf HENHMETAFILE) bool {
-	ret, _, _ := syscall.Syscall(deleteEnhMetaFile, 1,
+	ret, _, _ := syscall.Syscall(deleteEnhMetaFile.Addr(), 1,
 		uintptr(hemf),
 		0,
 		0)
@@ -1411,7 +1412,7 @@ func DeleteEnhMetaFile(hemf HENHMETAFILE) bool {
 }
 
 func DeleteObject(hObject HGDIOBJ) bool {
-	ret, _, _ := syscall.Syscall(deleteObject, 1,
+	ret, _, _ := syscall.Syscall(deleteObject.Addr(), 1,
 		uintptr(hObject),
 		0,
 		0)
@@ -1420,7 +1421,7 @@ func DeleteObject(hObject HGDIOBJ) bool {
 }
 
 func Ellipse(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect int32) bool {
-	ret, _, _ := syscall.Syscall6(ellipse, 5,
+	ret, _, _ := syscall.Syscall6(ellipse.Addr(), 5,
 		uintptr(hdc),
 		uintptr(nLeftRect),
 		uintptr(nTopRect),
@@ -1432,7 +1433,7 @@ func Ellipse(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect int32) bool {
 }
 
 func EndDoc(hdc HDC) int32 {
-	ret, _, _ := syscall.Syscall(endDoc, 1,
+	ret, _, _ := syscall.Syscall(endDoc.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1441,7 +1442,7 @@ func EndDoc(hdc HDC) int32 {
 }
 
 func EndPage(hdc HDC) int32 {
-	ret, _, _ := syscall.Syscall(endPage, 1,
+	ret, _, _ := syscall.Syscall(endPage.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1450,7 +1451,7 @@ func EndPage(hdc HDC) int32 {
 }
 
 func ExcludeClipRect(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect int32) int32 {
-	ret, _, _ := syscall.Syscall6(excludeClipRect, 5,
+	ret, _, _ := syscall.Syscall6(excludeClipRect.Addr(), 5,
 		uintptr(hdc),
 		uintptr(nLeftRect),
 		uintptr(nTopRect),
@@ -1462,7 +1463,7 @@ func ExcludeClipRect(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect int32
 }
 
 func ExtCreatePen(dwPenStyle, dwWidth uint32, lplb *LOGBRUSH, dwStyleCount uint32, lpStyle *uint32) HPEN {
-	ret, _, _ := syscall.Syscall6(extCreatePen, 5,
+	ret, _, _ := syscall.Syscall6(extCreatePen.Addr(), 5,
 		uintptr(dwPenStyle),
 		uintptr(dwWidth),
 		uintptr(unsafe.Pointer(lplb)),
@@ -1474,7 +1475,7 @@ func ExtCreatePen(dwPenStyle, dwWidth uint32, lplb *LOGBRUSH, dwStyleCount uint3
 }
 
 func FillRgn(hdc HDC, hrgn HRGN, hbr HBRUSH) bool {
-	ret, _, _ := syscall.Syscall(fillRgn, 3,
+	ret, _, _ := syscall.Syscall(fillRgn.Addr(), 3,
 		uintptr(hdc),
 		uintptr(hrgn),
 		uintptr(hbr))
@@ -1483,7 +1484,7 @@ func FillRgn(hdc HDC, hrgn HRGN, hbr HBRUSH) bool {
 }
 
 func GdiFlush() bool {
-	ret, _, _ := syscall.Syscall(gdiFlush, 0,
+	ret, _, _ := syscall.Syscall(gdiFlush.Addr(), 0,
 		0,
 		0,
 		0)
@@ -1492,7 +1493,7 @@ func GdiFlush() bool {
 }
 
 func GetBkColor(hdc HDC) COLORREF {
-	ret, _, _ := syscall.Syscall(getBkColor, 1,
+	ret, _, _ := syscall.Syscall(getBkColor.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1501,7 +1502,7 @@ func GetBkColor(hdc HDC) COLORREF {
 }
 
 func GetDeviceCaps(hdc HDC, nIndex int32) int32 {
-	ret, _, _ := syscall.Syscall(getDeviceCaps, 2,
+	ret, _, _ := syscall.Syscall(getDeviceCaps.Addr(), 2,
 		uintptr(hdc),
 		uintptr(nIndex),
 		0)
@@ -1510,7 +1511,7 @@ func GetDeviceCaps(hdc HDC, nIndex int32) int32 {
 }
 
 func GetDIBits(hdc HDC, hbmp HBITMAP, uStartScan uint32, cScanLines uint32, lpvBits *byte, lpbi *BITMAPINFO, uUsage uint32) int32 {
-	ret, _, _ := syscall.Syscall9(getDIBits, 7,
+	ret, _, _ := syscall.Syscall9(getDIBits.Addr(), 7,
 		uintptr(hdc),
 		uintptr(hbmp),
 		uintptr(uStartScan),
@@ -1524,7 +1525,7 @@ func GetDIBits(hdc HDC, hbmp HBITMAP, uStartScan uint32, cScanLines uint32, lpvB
 }
 
 func GetEnhMetaFile(lpszMetaFile *uint16) HENHMETAFILE {
-	ret, _, _ := syscall.Syscall(getEnhMetaFile, 1,
+	ret, _, _ := syscall.Syscall(getEnhMetaFile.Addr(), 1,
 		uintptr(unsafe.Pointer(lpszMetaFile)),
 		0,
 		0)
@@ -1533,7 +1534,7 @@ func GetEnhMetaFile(lpszMetaFile *uint16) HENHMETAFILE {
 }
 
 func GetEnhMetaFileHeader(hemf HENHMETAFILE, cbBuffer uint32, lpemh *ENHMETAHEADER) uint32 {
-	ret, _, _ := syscall.Syscall(getEnhMetaFileHeader, 3,
+	ret, _, _ := syscall.Syscall(getEnhMetaFileHeader.Addr(), 3,
 		uintptr(hemf),
 		uintptr(cbBuffer),
 		uintptr(unsafe.Pointer(lpemh)))
@@ -1542,7 +1543,7 @@ func GetEnhMetaFileHeader(hemf HENHMETAFILE, cbBuffer uint32, lpemh *ENHMETAHEAD
 }
 
 func GetObject(hgdiobj HGDIOBJ, cbBuffer uintptr, lpvObject unsafe.Pointer) int32 {
-	ret, _, _ := syscall.Syscall(getObject, 3,
+	ret, _, _ := syscall.Syscall(getObject.Addr(), 3,
 		uintptr(hgdiobj),
 		uintptr(cbBuffer),
 		uintptr(lpvObject))
@@ -1551,7 +1552,7 @@ func GetObject(hgdiobj HGDIOBJ, cbBuffer uintptr, lpvObject unsafe.Pointer) int3
 }
 
 func GetPixel(hdc HDC, nXPos, nYPos int32) COLORREF {
-	ret, _, _ := syscall.Syscall(getPixel, 3,
+	ret, _, _ := syscall.Syscall(getPixel.Addr(), 3,
 		uintptr(hdc),
 		uintptr(nXPos),
 		uintptr(nYPos))
@@ -1560,7 +1561,7 @@ func GetPixel(hdc HDC, nXPos, nYPos int32) COLORREF {
 }
 
 func GetRgnBox(hrgn HRGN, lprc *RECT) int32 {
-	ret, _, _ := syscall.Syscall(getRgnBox, 2,
+	ret, _, _ := syscall.Syscall(getRgnBox.Addr(), 2,
 		uintptr(hrgn),
 		uintptr(unsafe.Pointer(lprc)),
 		0)
@@ -1569,7 +1570,7 @@ func GetRgnBox(hrgn HRGN, lprc *RECT) int32 {
 }
 
 func GetStockObject(fnObject int32) HGDIOBJ {
-	ret, _, _ := syscall.Syscall(getStockObject, 1,
+	ret, _, _ := syscall.Syscall(getStockObject.Addr(), 1,
 		uintptr(fnObject),
 		0,
 		0)
@@ -1578,7 +1579,7 @@ func GetStockObject(fnObject int32) HGDIOBJ {
 }
 
 func GetTextColor(hdc HDC) COLORREF {
-	ret, _, _ := syscall.Syscall(getTextColor, 1,
+	ret, _, _ := syscall.Syscall(getTextColor.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1587,7 +1588,7 @@ func GetTextColor(hdc HDC) COLORREF {
 }
 
 func GetTextExtentExPoint(hdc HDC, lpszStr *uint16, cchString, nMaxExtent int32, lpnFit, alpDx *int32, lpSize *SIZE) bool {
-	ret, _, _ := syscall.Syscall9(getTextExtentExPoint, 7,
+	ret, _, _ := syscall.Syscall9(getTextExtentExPoint.Addr(), 7,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(lpszStr)),
 		uintptr(cchString),
@@ -1602,7 +1603,7 @@ func GetTextExtentExPoint(hdc HDC, lpszStr *uint16, cchString, nMaxExtent int32,
 }
 
 func GetTextExtentPoint32(hdc HDC, lpString *uint16, c int32, lpSize *SIZE) bool {
-	ret, _, _ := syscall.Syscall6(getTextExtentPoint32, 4,
+	ret, _, _ := syscall.Syscall6(getTextExtentPoint32.Addr(), 4,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(lpString)),
 		uintptr(c),
@@ -1614,7 +1615,7 @@ func GetTextExtentPoint32(hdc HDC, lpString *uint16, c int32, lpSize *SIZE) bool
 }
 
 func GetTextMetrics(hdc HDC, lptm *TEXTMETRIC) bool {
-	ret, _, _ := syscall.Syscall(getTextMetrics, 2,
+	ret, _, _ := syscall.Syscall(getTextMetrics.Addr(), 2,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(lptm)),
 		0)
@@ -1623,7 +1624,7 @@ func GetTextMetrics(hdc HDC, lptm *TEXTMETRIC) bool {
 }
 
 func GetViewportOrgEx(hdc HDC, lpPoint *POINT) bool {
-	ret, _, _ := syscall.Syscall(getViewportOrgEx, 2,
+	ret, _, _ := syscall.Syscall(getViewportOrgEx.Addr(), 2,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(lpPoint)),
 		0)
@@ -1632,7 +1633,7 @@ func GetViewportOrgEx(hdc HDC, lpPoint *POINT) bool {
 }
 
 func GradientFill(hdc HDC, pVertex *TRIVERTEX, nVertex uint32, pMesh unsafe.Pointer, nMesh, ulMode uint32) bool {
-	ret, _, _ := syscall.Syscall6(gradientFill, 6,
+	ret, _, _ := syscall.Syscall6(gradientFill.Addr(), 6,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(pVertex)),
 		uintptr(nVertex),
@@ -1644,7 +1645,7 @@ func GradientFill(hdc HDC, pVertex *TRIVERTEX, nVertex uint32, pMesh unsafe.Poin
 }
 
 func IntersectClipRect(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect int32) int32 {
-	ret, _, _ := syscall.Syscall6(intersectClipRect, 5,
+	ret, _, _ := syscall.Syscall6(intersectClipRect.Addr(), 5,
 		uintptr(hdc),
 		uintptr(nLeftRect),
 		uintptr(nTopRect),
@@ -1656,7 +1657,7 @@ func IntersectClipRect(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect int
 }
 
 func LineTo(hdc HDC, nXEnd, nYEnd int32) bool {
-	ret, _, _ := syscall.Syscall(lineTo, 3,
+	ret, _, _ := syscall.Syscall(lineTo.Addr(), 3,
 		uintptr(hdc),
 		uintptr(nXEnd),
 		uintptr(nYEnd))
@@ -1665,7 +1666,7 @@ func LineTo(hdc HDC, nXEnd, nYEnd int32) bool {
 }
 
 func MoveToEx(hdc HDC, x, y int, lpPoint *POINT) bool {
-	ret, _, _ := syscall.Syscall6(moveToEx, 4,
+	ret, _, _ := syscall.Syscall6(moveToEx.Addr(), 4,
 		uintptr(hdc),
 		uintptr(x),
 		uintptr(y),
@@ -1677,7 +1678,7 @@ func MoveToEx(hdc HDC, x, y int, lpPoint *POINT) bool {
 }
 
 func PlayEnhMetaFile(hdc HDC, hemf HENHMETAFILE, lpRect *RECT) bool {
-	ret, _, _ := syscall.Syscall(playEnhMetaFile, 3,
+	ret, _, _ := syscall.Syscall(playEnhMetaFile.Addr(), 3,
 		uintptr(hdc),
 		uintptr(hemf),
 		uintptr(unsafe.Pointer(lpRect)))
@@ -1686,7 +1687,7 @@ func PlayEnhMetaFile(hdc HDC, hemf HENHMETAFILE, lpRect *RECT) bool {
 }
 
 func Polyline(hdc HDC, lppt unsafe.Pointer, cPoints int32) bool {
-	ret, _, _ := syscall.Syscall(polyline, 3,
+	ret, _, _ := syscall.Syscall(polyline.Addr(), 3,
 		uintptr(hdc),
 		uintptr(lppt),
 		uintptr(cPoints))
@@ -1695,7 +1696,7 @@ func Polyline(hdc HDC, lppt unsafe.Pointer, cPoints int32) bool {
 }
 
 func Rectangle_(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect int32) bool {
-	ret, _, _ := syscall.Syscall6(rectangle, 5,
+	ret, _, _ := syscall.Syscall6(rectangle.Addr(), 5,
 		uintptr(hdc),
 		uintptr(nLeftRect),
 		uintptr(nTopRect),
@@ -1707,7 +1708,7 @@ func Rectangle_(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect int32) boo
 }
 
 func RemoveFontResourceEx(lpszFilename *uint16, fl uint32, pdv unsafe.Pointer) bool {
-	ret, _, _ := syscall.Syscall(removeFontResourceEx, 3,
+	ret, _, _ := syscall.Syscall(removeFontResourceEx.Addr(), 3,
 		uintptr(unsafe.Pointer(lpszFilename)),
 		uintptr(fl),
 		uintptr(pdv))
@@ -1716,7 +1717,7 @@ func RemoveFontResourceEx(lpszFilename *uint16, fl uint32, pdv unsafe.Pointer) b
 }
 
 func ResetDC(hdc HDC, lpInitData *DEVMODE) HDC {
-	ret, _, _ := syscall.Syscall(resetDC, 2,
+	ret, _, _ := syscall.Syscall(resetDC.Addr(), 2,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(lpInitData)),
 		0)
@@ -1725,7 +1726,7 @@ func ResetDC(hdc HDC, lpInitData *DEVMODE) HDC {
 }
 
 func RestoreDC(hdc HDC, nSaveDC int32) bool {
-	ret, _, _ := syscall.Syscall(restoreDC, 2,
+	ret, _, _ := syscall.Syscall(restoreDC.Addr(), 2,
 		uintptr(hdc),
 		uintptr(nSaveDC),
 		0)
@@ -1733,7 +1734,7 @@ func RestoreDC(hdc HDC, nSaveDC int32) bool {
 }
 
 func RoundRect(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect, nWidth, nHeight int32) bool {
-	ret, _, _ := syscall.Syscall9(roundRect, 7,
+	ret, _, _ := syscall.Syscall9(roundRect.Addr(), 7,
 		uintptr(hdc),
 		uintptr(nLeftRect),
 		uintptr(nTopRect),
@@ -1748,7 +1749,7 @@ func RoundRect(hdc HDC, nLeftRect, nTopRect, nRightRect, nBottomRect, nWidth, nH
 }
 
 func SaveDC(hdc HDC) int32 {
-	ret, _, _ := syscall.Syscall(saveDC, 1,
+	ret, _, _ := syscall.Syscall(saveDC.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1756,7 +1757,7 @@ func SaveDC(hdc HDC) int32 {
 }
 
 func SelectObject(hdc HDC, hgdiobj HGDIOBJ) HGDIOBJ {
-	ret, _, _ := syscall.Syscall(selectObject, 2,
+	ret, _, _ := syscall.Syscall(selectObject.Addr(), 2,
 		uintptr(hdc),
 		uintptr(hgdiobj),
 		0)
@@ -1765,7 +1766,7 @@ func SelectObject(hdc HDC, hgdiobj HGDIOBJ) HGDIOBJ {
 }
 
 func SetBkColor(hdc HDC, crColor COLORREF) COLORREF {
-	ret, _, _ := syscall.Syscall(setBkColor, 2,
+	ret, _, _ := syscall.Syscall(setBkColor.Addr(), 2,
 		uintptr(hdc),
 		uintptr(crColor),
 		0)
@@ -1774,7 +1775,7 @@ func SetBkColor(hdc HDC, crColor COLORREF) COLORREF {
 }
 
 func SetBkMode(hdc HDC, iBkMode int32) int32 {
-	ret, _, _ := syscall.Syscall(setBkMode, 2,
+	ret, _, _ := syscall.Syscall(setBkMode.Addr(), 2,
 		uintptr(hdc),
 		uintptr(iBkMode),
 		0)
@@ -1783,7 +1784,7 @@ func SetBkMode(hdc HDC, iBkMode int32) int32 {
 }
 
 func SetBrushOrgEx(hdc HDC, nXOrg, nYOrg int32, lppt *POINT) bool {
-	ret, _, _ := syscall.Syscall6(setBrushOrgEx, 4,
+	ret, _, _ := syscall.Syscall6(setBrushOrgEx.Addr(), 4,
 		uintptr(hdc),
 		uintptr(nXOrg),
 		uintptr(nYOrg),
@@ -1795,7 +1796,7 @@ func SetBrushOrgEx(hdc HDC, nXOrg, nYOrg int32, lppt *POINT) bool {
 }
 
 func SetDIBits(hdc HDC, hbmp HBITMAP, uStartScan, cScanLines uint32, lpvBits *byte, lpbmi *BITMAPINFO, fuColorUse uint32) int32 {
-	ret, _, _ := syscall.Syscall9(setDIBits, 7,
+	ret, _, _ := syscall.Syscall9(setDIBits.Addr(), 7,
 		uintptr(hdc),
 		uintptr(hbmp),
 		uintptr(uStartScan),
@@ -1810,7 +1811,7 @@ func SetDIBits(hdc HDC, hbmp HBITMAP, uStartScan, cScanLines uint32, lpvBits *by
 }
 
 func SetPixel(hdc HDC, X, Y int32, crColor COLORREF) COLORREF {
-	ret, _, _ := syscall.Syscall6(setPixel, 4,
+	ret, _, _ := syscall.Syscall6(setPixel.Addr(), 4,
 		uintptr(hdc),
 		uintptr(X),
 		uintptr(Y),
@@ -1822,7 +1823,7 @@ func SetPixel(hdc HDC, X, Y int32, crColor COLORREF) COLORREF {
 }
 
 func SetPixelFormat(hdc HDC, iPixelFormat int32, ppfd *PIXELFORMATDESCRIPTOR) bool {
-	ret, _, _ := syscall.Syscall(setPixelFormat, 3,
+	ret, _, _ := syscall.Syscall(setPixelFormat.Addr(), 3,
 		uintptr(hdc),
 		uintptr(iPixelFormat),
 		uintptr(unsafe.Pointer(ppfd)))
@@ -1831,7 +1832,7 @@ func SetPixelFormat(hdc HDC, iPixelFormat int32, ppfd *PIXELFORMATDESCRIPTOR) bo
 }
 
 func SetStretchBltMode(hdc HDC, iStretchMode int32) int32 {
-	ret, _, _ := syscall.Syscall(setStretchBltMode, 2,
+	ret, _, _ := syscall.Syscall(setStretchBltMode.Addr(), 2,
 		uintptr(hdc),
 		uintptr(iStretchMode),
 		0)
@@ -1840,7 +1841,7 @@ func SetStretchBltMode(hdc HDC, iStretchMode int32) int32 {
 }
 
 func SetTextColor(hdc HDC, crColor COLORREF) COLORREF {
-	ret, _, _ := syscall.Syscall(setTextColor, 2,
+	ret, _, _ := syscall.Syscall(setTextColor.Addr(), 2,
 		uintptr(hdc),
 		uintptr(crColor),
 		0)
@@ -1849,7 +1850,7 @@ func SetTextColor(hdc HDC, crColor COLORREF) COLORREF {
 }
 
 func SetViewportOrgEx(hdc HDC, x, y int32, lpPoint *POINT) COLORREF {
-	ret, _, _ := syscall.Syscall6(setViewportOrgEx, 4,
+	ret, _, _ := syscall.Syscall6(setViewportOrgEx.Addr(), 4,
 		uintptr(hdc),
 		uintptr(x),
 		uintptr(y),
@@ -1861,7 +1862,7 @@ func SetViewportOrgEx(hdc HDC, x, y int32, lpPoint *POINT) COLORREF {
 }
 
 func StartDoc(hdc HDC, lpdi *DOCINFO) int32 {
-	ret, _, _ := syscall.Syscall(startDoc, 2,
+	ret, _, _ := syscall.Syscall(startDoc.Addr(), 2,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(lpdi)),
 		0)
@@ -1870,7 +1871,7 @@ func StartDoc(hdc HDC, lpdi *DOCINFO) int32 {
 }
 
 func StartPage(hdc HDC) int32 {
-	ret, _, _ := syscall.Syscall(startPage, 1,
+	ret, _, _ := syscall.Syscall(startPage.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1879,7 +1880,7 @@ func StartPage(hdc HDC) int32 {
 }
 
 func StretchBlt(hdcDest HDC, nXOriginDest, nYOriginDest, nWidthDest, nHeightDest int32, hdcSrc HDC, nXOriginSrc, nYOriginSrc, nWidthSrc, nHeightSrc int32, dwRop uint32) bool {
-	ret, _, _ := syscall.Syscall12(stretchBlt, 11,
+	ret, _, _ := syscall.Syscall12(stretchBlt.Addr(), 11,
 		uintptr(hdcDest),
 		uintptr(nXOriginDest),
 		uintptr(nYOriginDest),
@@ -1897,7 +1898,7 @@ func StretchBlt(hdcDest HDC, nXOriginDest, nYOriginDest, nWidthDest, nHeightDest
 }
 
 func SwapBuffers(hdc HDC) bool {
-	ret, _, _ := syscall.Syscall(swapBuffers, 1,
+	ret, _, _ := syscall.Syscall(swapBuffers.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -1906,7 +1907,7 @@ func SwapBuffers(hdc HDC) bool {
 }
 
 func TextOut(hdc HDC, nXStart, nYStart int32, lpString *uint16, cchString int32) bool {
-	ret, _, _ := syscall.Syscall6(textOut, 5,
+	ret, _, _ := syscall.Syscall6(textOut.Addr(), 5,
 		uintptr(hdc),
 		uintptr(nXStart),
 		uintptr(nYStart),
@@ -1917,7 +1918,7 @@ func TextOut(hdc HDC, nXStart, nYStart int32, lpString *uint16, cchString int32)
 }
 
 func TransparentBlt(hdcDest HDC, xoriginDest, yoriginDest, wDest, hDest int32, hdcSrc HDC, xoriginSrc, yoriginSrc, wSrc, hSrc int32, crTransparent uint32) bool {
-	ret, _, _ := syscall.Syscall12(transparentBlt, 11,
+	ret, _, _ := syscall.Syscall12(transparentBlt.Addr(), 11,
 		uintptr(hdcDest),
 		uintptr(xoriginDest),
 		uintptr(yoriginDest),

--- a/kernel32.go
+++ b/kernel32.go
@@ -7,6 +7,7 @@
 package win
 
 import (
+	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
 )
@@ -54,33 +55,33 @@ const (
 
 var (
 	// Library
-	libkernel32 uintptr
+	libkernel32 *windows.LazyDLL
 
 	// Functions
-	activateActCtx                     uintptr
-	closeHandle                        uintptr
-	createActCtx                       uintptr
-	fileTimeToSystemTime               uintptr
-	getConsoleTitle                    uintptr
-	getConsoleWindow                   uintptr
-	getLastError                       uintptr
-	getLocaleInfo                      uintptr
-	getLogicalDriveStrings             uintptr
-	getModuleHandle                    uintptr
-	getNumberFormat                    uintptr
-	getPhysicallyInstalledSystemMemory uintptr
-	getProfileString                   uintptr
-	getThreadLocale                    uintptr
-	getThreadUILanguage                uintptr
-	getVersion                         uintptr
-	globalAlloc                        uintptr
-	globalFree                         uintptr
-	globalLock                         uintptr
-	globalUnlock                       uintptr
-	moveMemory                         uintptr
-	mulDiv                             uintptr
-	setLastError                       uintptr
-	systemTimeToFileTime               uintptr
+	activateActCtx                     *windows.LazyProc
+	closeHandle                        *windows.LazyProc
+	createActCtx                       *windows.LazyProc
+	fileTimeToSystemTime               *windows.LazyProc
+	getConsoleTitle                    *windows.LazyProc
+	getConsoleWindow                   *windows.LazyProc
+	getLastError                       *windows.LazyProc
+	getLocaleInfo                      *windows.LazyProc
+	getLogicalDriveStrings             *windows.LazyProc
+	getModuleHandle                    *windows.LazyProc
+	getNumberFormat                    *windows.LazyProc
+	getPhysicallyInstalledSystemMemory *windows.LazyProc
+	getProfileString                   *windows.LazyProc
+	getThreadLocale                    *windows.LazyProc
+	getThreadUILanguage                *windows.LazyProc
+	getVersion                         *windows.LazyProc
+	globalAlloc                        *windows.LazyProc
+	globalFree                         *windows.LazyProc
+	globalLock                         *windows.LazyProc
+	globalUnlock                       *windows.LazyProc
+	moveMemory                         *windows.LazyProc
+	mulDiv                             *windows.LazyProc
+	setLastError                       *windows.LazyProc
+	systemTimeToFileTime               *windows.LazyProc
 )
 
 type (
@@ -134,38 +135,38 @@ type ACTCTX struct {
 
 func init() {
 	// Library
-	libkernel32 = MustLoadLibrary("kernel32.dll")
+	libkernel32 = windows.NewLazySystemDLL("kernel32.dll")
 
 	// Functions
-	activateActCtx = MustGetProcAddress(libkernel32, "ActivateActCtx")
-	closeHandle = MustGetProcAddress(libkernel32, "CloseHandle")
-	createActCtx = MustGetProcAddress(libkernel32, "CreateActCtxW")
-	fileTimeToSystemTime = MustGetProcAddress(libkernel32, "FileTimeToSystemTime")
-	getConsoleTitle = MustGetProcAddress(libkernel32, "GetConsoleTitleW")
-	getConsoleWindow = MustGetProcAddress(libkernel32, "GetConsoleWindow")
-	getLastError = MustGetProcAddress(libkernel32, "GetLastError")
-	getLocaleInfo = MustGetProcAddress(libkernel32, "GetLocaleInfoW")
-	getLogicalDriveStrings = MustGetProcAddress(libkernel32, "GetLogicalDriveStringsW")
-	getModuleHandle = MustGetProcAddress(libkernel32, "GetModuleHandleW")
-	getNumberFormat = MustGetProcAddress(libkernel32, "GetNumberFormatW")
-	getPhysicallyInstalledSystemMemory, _ = syscall.GetProcAddress(syscall.Handle(libkernel32), "GetPhysicallyInstalledSystemMemory")
-	getProfileString = MustGetProcAddress(libkernel32, "GetProfileStringW")
-	getThreadLocale = MustGetProcAddress(libkernel32, "GetThreadLocale")
-	getThreadUILanguage, _ = syscall.GetProcAddress(syscall.Handle(libkernel32), "GetThreadUILanguage")
-	getVersion = MustGetProcAddress(libkernel32, "GetVersion")
-	globalAlloc = MustGetProcAddress(libkernel32, "GlobalAlloc")
-	globalFree = MustGetProcAddress(libkernel32, "GlobalFree")
-	globalLock = MustGetProcAddress(libkernel32, "GlobalLock")
-	globalUnlock = MustGetProcAddress(libkernel32, "GlobalUnlock")
-	moveMemory = MustGetProcAddress(libkernel32, "RtlMoveMemory")
-	mulDiv = MustGetProcAddress(libkernel32, "MulDiv")
-	setLastError = MustGetProcAddress(libkernel32, "SetLastError")
-	systemTimeToFileTime = MustGetProcAddress(libkernel32, "SystemTimeToFileTime")
+	activateActCtx = libkernel32.NewProc("ActivateActCtx")
+	closeHandle = libkernel32.NewProc("CloseHandle")
+	createActCtx = libkernel32.NewProc("CreateActCtxW")
+	fileTimeToSystemTime = libkernel32.NewProc("FileTimeToSystemTime")
+	getConsoleTitle = libkernel32.NewProc("GetConsoleTitleW")
+	getConsoleWindow = libkernel32.NewProc("GetConsoleWindow")
+	getLastError = libkernel32.NewProc("GetLastError")
+	getLocaleInfo = libkernel32.NewProc("GetLocaleInfoW")
+	getLogicalDriveStrings = libkernel32.NewProc("GetLogicalDriveStringsW")
+	getModuleHandle = libkernel32.NewProc("GetModuleHandleW")
+	getNumberFormat = libkernel32.NewProc("GetNumberFormatW")
+	getPhysicallyInstalledSystemMemory = libkernel32.NewProc("GetPhysicallyInstalledSystemMemory")
+	getProfileString = libkernel32.NewProc("GetProfileStringW")
+	getThreadLocale = libkernel32.NewProc("GetThreadLocale")
+	getThreadUILanguage = libkernel32.NewProc("GetThreadUILanguage")
+	getVersion = libkernel32.NewProc("GetVersion")
+	globalAlloc = libkernel32.NewProc("GlobalAlloc")
+	globalFree = libkernel32.NewProc("GlobalFree")
+	globalLock = libkernel32.NewProc("GlobalLock")
+	globalUnlock = libkernel32.NewProc("GlobalUnlock")
+	moveMemory = libkernel32.NewProc("RtlMoveMemory")
+	mulDiv = libkernel32.NewProc("MulDiv")
+	setLastError = libkernel32.NewProc("SetLastError")
+	systemTimeToFileTime = libkernel32.NewProc("SystemTimeToFileTime")
 }
 
 func ActivateActCtx(ctx HANDLE) (uintptr, bool) {
 	var cookie uintptr
-	ret, _, _ := syscall.Syscall(activateActCtx, 2,
+	ret, _, _ := syscall.Syscall(activateActCtx.Addr(), 2,
 		uintptr(ctx),
 		uintptr(unsafe.Pointer(&cookie)),
 		0)
@@ -173,7 +174,7 @@ func ActivateActCtx(ctx HANDLE) (uintptr, bool) {
 }
 
 func CloseHandle(hObject HANDLE) bool {
-	ret, _, _ := syscall.Syscall(closeHandle, 1,
+	ret, _, _ := syscall.Syscall(closeHandle.Addr(), 1,
 		uintptr(hObject),
 		0,
 		0)
@@ -186,7 +187,7 @@ func CreateActCtx(ctx *ACTCTX) HANDLE {
 		ctx.size = uint32(unsafe.Sizeof(*ctx))
 	}
 	ret, _, _ := syscall.Syscall(
-		createActCtx,
+		createActCtx.Addr(),
 		1,
 		uintptr(unsafe.Pointer(ctx)),
 		0,
@@ -195,7 +196,7 @@ func CreateActCtx(ctx *ACTCTX) HANDLE {
 }
 
 func FileTimeToSystemTime(lpFileTime *FILETIME, lpSystemTime *SYSTEMTIME) bool {
-	ret, _, _ := syscall.Syscall(fileTimeToSystemTime, 2,
+	ret, _, _ := syscall.Syscall(fileTimeToSystemTime.Addr(), 2,
 		uintptr(unsafe.Pointer(lpFileTime)),
 		uintptr(unsafe.Pointer(lpSystemTime)),
 		0)
@@ -204,7 +205,7 @@ func FileTimeToSystemTime(lpFileTime *FILETIME, lpSystemTime *SYSTEMTIME) bool {
 }
 
 func GetConsoleTitle(lpConsoleTitle *uint16, nSize uint32) uint32 {
-	ret, _, _ := syscall.Syscall(getConsoleTitle, 2,
+	ret, _, _ := syscall.Syscall(getConsoleTitle.Addr(), 2,
 		uintptr(unsafe.Pointer(lpConsoleTitle)),
 		uintptr(nSize),
 		0)
@@ -213,7 +214,7 @@ func GetConsoleTitle(lpConsoleTitle *uint16, nSize uint32) uint32 {
 }
 
 func GetConsoleWindow() HWND {
-	ret, _, _ := syscall.Syscall(getConsoleWindow, 0,
+	ret, _, _ := syscall.Syscall(getConsoleWindow.Addr(), 0,
 		0,
 		0,
 		0)
@@ -222,7 +223,7 @@ func GetConsoleWindow() HWND {
 }
 
 func GetLastError() uint32 {
-	ret, _, _ := syscall.Syscall(getLastError, 0,
+	ret, _, _ := syscall.Syscall(getLastError.Addr(), 0,
 		0,
 		0,
 		0)
@@ -231,7 +232,7 @@ func GetLastError() uint32 {
 }
 
 func GetLocaleInfo(Locale LCID, LCType LCTYPE, lpLCData *uint16, cchData int32) int32 {
-	ret, _, _ := syscall.Syscall6(getLocaleInfo, 4,
+	ret, _, _ := syscall.Syscall6(getLocaleInfo.Addr(), 4,
 		uintptr(Locale),
 		uintptr(LCType),
 		uintptr(unsafe.Pointer(lpLCData)),
@@ -243,7 +244,7 @@ func GetLocaleInfo(Locale LCID, LCType LCTYPE, lpLCData *uint16, cchData int32) 
 }
 
 func GetLogicalDriveStrings(nBufferLength uint32, lpBuffer *uint16) uint32 {
-	ret, _, _ := syscall.Syscall(getLogicalDriveStrings, 2,
+	ret, _, _ := syscall.Syscall(getLogicalDriveStrings.Addr(), 2,
 		uintptr(nBufferLength),
 		uintptr(unsafe.Pointer(lpBuffer)),
 		0)
@@ -252,7 +253,7 @@ func GetLogicalDriveStrings(nBufferLength uint32, lpBuffer *uint16) uint32 {
 }
 
 func GetModuleHandle(lpModuleName *uint16) HINSTANCE {
-	ret, _, _ := syscall.Syscall(getModuleHandle, 1,
+	ret, _, _ := syscall.Syscall(getModuleHandle.Addr(), 1,
 		uintptr(unsafe.Pointer(lpModuleName)),
 		0,
 		0)
@@ -261,7 +262,7 @@ func GetModuleHandle(lpModuleName *uint16) HINSTANCE {
 }
 
 func GetNumberFormat(Locale LCID, dwFlags uint32, lpValue *uint16, lpFormat *NUMBERFMT, lpNumberStr *uint16, cchNumber int32) int32 {
-	ret, _, _ := syscall.Syscall6(getNumberFormat, 6,
+	ret, _, _ := syscall.Syscall6(getNumberFormat.Addr(), 6,
 		uintptr(Locale),
 		uintptr(dwFlags),
 		uintptr(unsafe.Pointer(lpValue)),
@@ -273,7 +274,10 @@ func GetNumberFormat(Locale LCID, dwFlags uint32, lpValue *uint16, lpFormat *NUM
 }
 
 func GetPhysicallyInstalledSystemMemory(totalMemoryInKilobytes *uint64) bool {
-	ret, _, _ := syscall.Syscall(getPhysicallyInstalledSystemMemory, 1,
+	if getPhysicallyInstalledSystemMemory.Find() != nil {
+		return false
+	}
+	ret, _, _ := syscall.Syscall(getPhysicallyInstalledSystemMemory.Addr(), 1,
 		uintptr(unsafe.Pointer(totalMemoryInKilobytes)),
 		0,
 		0)
@@ -282,7 +286,7 @@ func GetPhysicallyInstalledSystemMemory(totalMemoryInKilobytes *uint64) bool {
 }
 
 func GetProfileString(lpAppName, lpKeyName, lpDefault *uint16, lpReturnedString uintptr, nSize uint32) bool {
-	ret, _, _ := syscall.Syscall6(getProfileString, 5,
+	ret, _, _ := syscall.Syscall6(getProfileString.Addr(), 5,
 		uintptr(unsafe.Pointer(lpAppName)),
 		uintptr(unsafe.Pointer(lpKeyName)),
 		uintptr(unsafe.Pointer(lpDefault)),
@@ -293,7 +297,7 @@ func GetProfileString(lpAppName, lpKeyName, lpDefault *uint16, lpReturnedString 
 }
 
 func GetThreadLocale() LCID {
-	ret, _, _ := syscall.Syscall(getThreadLocale, 0,
+	ret, _, _ := syscall.Syscall(getThreadLocale.Addr(), 0,
 		0,
 		0,
 		0)
@@ -302,11 +306,11 @@ func GetThreadLocale() LCID {
 }
 
 func GetThreadUILanguage() LANGID {
-	if getThreadUILanguage == 0 {
+	if getThreadUILanguage.Find() != nil {
 		return 0
 	}
 
-	ret, _, _ := syscall.Syscall(getThreadUILanguage, 0,
+	ret, _, _ := syscall.Syscall(getThreadUILanguage.Addr(), 0,
 		0,
 		0,
 		0)
@@ -315,7 +319,7 @@ func GetThreadUILanguage() LANGID {
 }
 
 func GetVersion() int64 {
-	ret, _, _ := syscall.Syscall(getVersion, 0,
+	ret, _, _ := syscall.Syscall(getVersion.Addr(), 0,
 		0,
 		0,
 		0)
@@ -323,7 +327,7 @@ func GetVersion() int64 {
 }
 
 func GlobalAlloc(uFlags uint32, dwBytes uintptr) HGLOBAL {
-	ret, _, _ := syscall.Syscall(globalAlloc, 2,
+	ret, _, _ := syscall.Syscall(globalAlloc.Addr(), 2,
 		uintptr(uFlags),
 		dwBytes,
 		0)
@@ -332,7 +336,7 @@ func GlobalAlloc(uFlags uint32, dwBytes uintptr) HGLOBAL {
 }
 
 func GlobalFree(hMem HGLOBAL) HGLOBAL {
-	ret, _, _ := syscall.Syscall(globalFree, 1,
+	ret, _, _ := syscall.Syscall(globalFree.Addr(), 1,
 		uintptr(hMem),
 		0,
 		0)
@@ -341,7 +345,7 @@ func GlobalFree(hMem HGLOBAL) HGLOBAL {
 }
 
 func GlobalLock(hMem HGLOBAL) unsafe.Pointer {
-	ret, _, _ := syscall.Syscall(globalLock, 1,
+	ret, _, _ := syscall.Syscall(globalLock.Addr(), 1,
 		uintptr(hMem),
 		0,
 		0)
@@ -350,7 +354,7 @@ func GlobalLock(hMem HGLOBAL) unsafe.Pointer {
 }
 
 func GlobalUnlock(hMem HGLOBAL) bool {
-	ret, _, _ := syscall.Syscall(globalUnlock, 1,
+	ret, _, _ := syscall.Syscall(globalUnlock.Addr(), 1,
 		uintptr(hMem),
 		0,
 		0)
@@ -359,14 +363,14 @@ func GlobalUnlock(hMem HGLOBAL) bool {
 }
 
 func MoveMemory(destination, source unsafe.Pointer, length uintptr) {
-	syscall.Syscall(moveMemory, 3,
+	syscall.Syscall(moveMemory.Addr(), 3,
 		uintptr(unsafe.Pointer(destination)),
 		uintptr(source),
 		uintptr(length))
 }
 
 func MulDiv(nNumber, nNumerator, nDenominator int32) int32 {
-	ret, _, _ := syscall.Syscall(mulDiv, 3,
+	ret, _, _ := syscall.Syscall(mulDiv.Addr(), 3,
 		uintptr(nNumber),
 		uintptr(nNumerator),
 		uintptr(nDenominator))
@@ -375,14 +379,14 @@ func MulDiv(nNumber, nNumerator, nDenominator int32) int32 {
 }
 
 func SetLastError(dwErrorCode uint32) {
-	syscall.Syscall(setLastError, 1,
+	syscall.Syscall(setLastError.Addr(), 1,
 		uintptr(dwErrorCode),
 		0,
 		0)
 }
 
 func SystemTimeToFileTime(lpSystemTime *SYSTEMTIME, lpFileTime *FILETIME) bool {
-	ret, _, _ := syscall.Syscall(systemTimeToFileTime, 2,
+	ret, _, _ := syscall.Syscall(systemTimeToFileTime.Addr(), 2,
 		uintptr(unsafe.Pointer(lpSystemTime)),
 		uintptr(unsafe.Pointer(lpFileTime)),
 		0)

--- a/opengl32.go
+++ b/opengl32.go
@@ -7,6 +7,7 @@
 package win
 
 import (
+	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
 )
@@ -91,52 +92,52 @@ type GLYPHMETRICSFLOAT struct {
 
 var (
 	// Library
-	lib uintptr
+	lib *windows.LazyDLL
 
 	// Functions
-	wglCopyContext            uintptr
-	wglCreateContext          uintptr
-	wglCreateLayerContext     uintptr
-	wglDeleteContext          uintptr
-	wglDescribeLayerPlane     uintptr
-	wglGetCurrentContext      uintptr
-	wglGetCurrentDC           uintptr
-	wglGetLayerPaletteEntries uintptr
-	wglGetProcAddress         uintptr
-	wglMakeCurrent            uintptr
-	wglRealizeLayerPalette    uintptr
-	wglSetLayerPaletteEntries uintptr
-	wglShareLists             uintptr
-	wglSwapLayerBuffers       uintptr
-	wglUseFontBitmaps         uintptr
-	wglUseFontOutlines        uintptr
+	wglCopyContext            *windows.LazyProc
+	wglCreateContext          *windows.LazyProc
+	wglCreateLayerContext     *windows.LazyProc
+	wglDeleteContext          *windows.LazyProc
+	wglDescribeLayerPlane     *windows.LazyProc
+	wglGetCurrentContext      *windows.LazyProc
+	wglGetCurrentDC           *windows.LazyProc
+	wglGetLayerPaletteEntries *windows.LazyProc
+	wglGetProcAddress         *windows.LazyProc
+	wglMakeCurrent            *windows.LazyProc
+	wglRealizeLayerPalette    *windows.LazyProc
+	wglSetLayerPaletteEntries *windows.LazyProc
+	wglShareLists             *windows.LazyProc
+	wglSwapLayerBuffers       *windows.LazyProc
+	wglUseFontBitmaps         *windows.LazyProc
+	wglUseFontOutlines        *windows.LazyProc
 )
 
 func init() {
 	// Library
-	lib = MustLoadLibrary("opengl32.dll")
+	lib = windows.NewLazySystemDLL("opengl32.dll")
 
 	// Functions
-	wglCopyContext = MustGetProcAddress(lib, "wglCopyContext")
-	wglCreateContext = MustGetProcAddress(lib, "wglCreateContext")
-	wglCreateLayerContext = MustGetProcAddress(lib, "wglCreateLayerContext")
-	wglDeleteContext = MustGetProcAddress(lib, "wglDeleteContext")
-	wglDescribeLayerPlane = MustGetProcAddress(lib, "wglDescribeLayerPlane")
-	wglGetCurrentContext = MustGetProcAddress(lib, "wglGetCurrentContext")
-	wglGetCurrentDC = MustGetProcAddress(lib, "wglGetCurrentDC")
-	wglGetLayerPaletteEntries = MustGetProcAddress(lib, "wglGetLayerPaletteEntries")
-	wglGetProcAddress = MustGetProcAddress(lib, "wglGetProcAddress")
-	wglMakeCurrent = MustGetProcAddress(lib, "wglMakeCurrent")
-	wglRealizeLayerPalette = MustGetProcAddress(lib, "wglRealizeLayerPalette")
-	wglSetLayerPaletteEntries = MustGetProcAddress(lib, "wglSetLayerPaletteEntries")
-	wglShareLists = MustGetProcAddress(lib, "wglShareLists")
-	wglSwapLayerBuffers = MustGetProcAddress(lib, "wglSwapLayerBuffers")
-	wglUseFontBitmaps = MustGetProcAddress(lib, "wglUseFontBitmapsW")
-	wglUseFontOutlines = MustGetProcAddress(lib, "wglUseFontOutlinesW")
+	wglCopyContext = lib.NewProc("wglCopyContext")
+	wglCreateContext = lib.NewProc("wglCreateContext")
+	wglCreateLayerContext = lib.NewProc("wglCreateLayerContext")
+	wglDeleteContext = lib.NewProc("wglDeleteContext")
+	wglDescribeLayerPlane = lib.NewProc("wglDescribeLayerPlane")
+	wglGetCurrentContext = lib.NewProc("wglGetCurrentContext")
+	wglGetCurrentDC = lib.NewProc("wglGetCurrentDC")
+	wglGetLayerPaletteEntries = lib.NewProc("wglGetLayerPaletteEntries")
+	wglGetProcAddress = lib.NewProc("wglGetProcAddress")
+	wglMakeCurrent = lib.NewProc("wglMakeCurrent")
+	wglRealizeLayerPalette = lib.NewProc("wglRealizeLayerPalette")
+	wglSetLayerPaletteEntries = lib.NewProc("wglSetLayerPaletteEntries")
+	wglShareLists = lib.NewProc("wglShareLists")
+	wglSwapLayerBuffers = lib.NewProc("wglSwapLayerBuffers")
+	wglUseFontBitmaps = lib.NewProc("wglUseFontBitmapsW")
+	wglUseFontOutlines = lib.NewProc("wglUseFontOutlinesW")
 }
 
 func WglCopyContext(hglrcSrc, hglrcDst HGLRC, mask uint) bool {
-	ret, _, _ := syscall.Syscall(wglCopyContext, 3,
+	ret, _, _ := syscall.Syscall(wglCopyContext.Addr(), 3,
 		uintptr(hglrcSrc),
 		uintptr(hglrcDst),
 		uintptr(mask))
@@ -145,7 +146,7 @@ func WglCopyContext(hglrcSrc, hglrcDst HGLRC, mask uint) bool {
 }
 
 func WglCreateContext(hdc HDC) HGLRC {
-	ret, _, _ := syscall.Syscall(wglCreateContext, 1,
+	ret, _, _ := syscall.Syscall(wglCreateContext.Addr(), 1,
 		uintptr(hdc),
 		0,
 		0)
@@ -154,7 +155,7 @@ func WglCreateContext(hdc HDC) HGLRC {
 }
 
 func WglCreateLayerContext(hdc HDC, iLayerPlane int) HGLRC {
-	ret, _, _ := syscall.Syscall(wglCreateLayerContext, 2,
+	ret, _, _ := syscall.Syscall(wglCreateLayerContext.Addr(), 2,
 		uintptr(hdc),
 		uintptr(iLayerPlane),
 		0)
@@ -163,7 +164,7 @@ func WglCreateLayerContext(hdc HDC, iLayerPlane int) HGLRC {
 }
 
 func WglDeleteContext(hglrc HGLRC) bool {
-	ret, _, _ := syscall.Syscall(wglDeleteContext, 1,
+	ret, _, _ := syscall.Syscall(wglDeleteContext.Addr(), 1,
 		uintptr(hglrc),
 		0,
 		0)
@@ -172,7 +173,7 @@ func WglDeleteContext(hglrc HGLRC) bool {
 }
 
 func WglDescribeLayerPlane(hdc HDC, iPixelFormat, iLayerPlane int, nBytes uint8, plpd *LAYERPLANEDESCRIPTOR) bool {
-	ret, _, _ := syscall.Syscall6(wglDescribeLayerPlane, 5,
+	ret, _, _ := syscall.Syscall6(wglDescribeLayerPlane.Addr(), 5,
 		uintptr(hdc),
 		uintptr(iPixelFormat),
 		uintptr(iLayerPlane),
@@ -184,7 +185,7 @@ func WglDescribeLayerPlane(hdc HDC, iPixelFormat, iLayerPlane int, nBytes uint8,
 }
 
 func WglGetCurrentContext() HGLRC {
-	ret, _, _ := syscall.Syscall(wglGetCurrentContext, 0,
+	ret, _, _ := syscall.Syscall(wglGetCurrentContext.Addr(), 0,
 		0,
 		0,
 		0)
@@ -193,7 +194,7 @@ func WglGetCurrentContext() HGLRC {
 }
 
 func WglGetCurrentDC() HDC {
-	ret, _, _ := syscall.Syscall(wglGetCurrentDC, 0,
+	ret, _, _ := syscall.Syscall(wglGetCurrentDC.Addr(), 0,
 		0,
 		0,
 		0)
@@ -202,7 +203,7 @@ func WglGetCurrentDC() HDC {
 }
 
 func WglGetLayerPaletteEntries(hdc HDC, iLayerPlane, iStart, cEntries int, pcr *COLORREF) int {
-	ret, _, _ := syscall.Syscall6(wglGetLayerPaletteEntries, 5,
+	ret, _, _ := syscall.Syscall6(wglGetLayerPaletteEntries.Addr(), 5,
 		uintptr(hdc),
 		uintptr(iLayerPlane),
 		uintptr(iStart),
@@ -214,7 +215,7 @@ func WglGetLayerPaletteEntries(hdc HDC, iLayerPlane, iStart, cEntries int, pcr *
 }
 
 func WglGetProcAddress(lpszProc *byte) uintptr {
-	ret, _, _ := syscall.Syscall(wglGetProcAddress, 1,
+	ret, _, _ := syscall.Syscall(wglGetProcAddress.Addr(), 1,
 		uintptr(unsafe.Pointer(lpszProc)),
 		0,
 		0)
@@ -223,7 +224,7 @@ func WglGetProcAddress(lpszProc *byte) uintptr {
 }
 
 func WglMakeCurrent(hdc HDC, hglrc HGLRC) bool {
-	ret, _, _ := syscall.Syscall(wglMakeCurrent, 2,
+	ret, _, _ := syscall.Syscall(wglMakeCurrent.Addr(), 2,
 		uintptr(hdc),
 		uintptr(hglrc),
 		0)
@@ -232,7 +233,7 @@ func WglMakeCurrent(hdc HDC, hglrc HGLRC) bool {
 }
 
 func WglRealizeLayerPalette(hdc HDC, iLayerPlane int, bRealize bool) bool {
-	ret, _, _ := syscall.Syscall(wglRealizeLayerPalette, 3,
+	ret, _, _ := syscall.Syscall(wglRealizeLayerPalette.Addr(), 3,
 		uintptr(hdc),
 		uintptr(iLayerPlane),
 		uintptr(BoolToBOOL(bRealize)))
@@ -241,7 +242,7 @@ func WglRealizeLayerPalette(hdc HDC, iLayerPlane int, bRealize bool) bool {
 }
 
 func WglSetLayerPaletteEntries(hdc HDC, iLayerPlane, iStart, cEntries int, pcr *COLORREF) int {
-	ret, _, _ := syscall.Syscall6(wglSetLayerPaletteEntries, 5,
+	ret, _, _ := syscall.Syscall6(wglSetLayerPaletteEntries.Addr(), 5,
 		uintptr(hdc),
 		uintptr(iLayerPlane),
 		uintptr(iStart),
@@ -253,7 +254,7 @@ func WglSetLayerPaletteEntries(hdc HDC, iLayerPlane, iStart, cEntries int, pcr *
 }
 
 func WglShareLists(hglrc1, hglrc2 HGLRC) bool {
-	ret, _, _ := syscall.Syscall(wglShareLists, 2,
+	ret, _, _ := syscall.Syscall(wglShareLists.Addr(), 2,
 		uintptr(hglrc1),
 		uintptr(hglrc2),
 		0)
@@ -262,7 +263,7 @@ func WglShareLists(hglrc1, hglrc2 HGLRC) bool {
 }
 
 func WglSwapLayerBuffers(hdc HDC, fuPlanes uint) bool {
-	ret, _, _ := syscall.Syscall(wglSwapLayerBuffers, 2,
+	ret, _, _ := syscall.Syscall(wglSwapLayerBuffers.Addr(), 2,
 		uintptr(hdc),
 		uintptr(fuPlanes),
 		0)
@@ -271,7 +272,7 @@ func WglSwapLayerBuffers(hdc HDC, fuPlanes uint) bool {
 }
 
 func WglUseFontBitmaps(hdc HDC, first, count, listbase uint32) bool {
-	ret, _, _ := syscall.Syscall6(wglUseFontBitmaps, 4,
+	ret, _, _ := syscall.Syscall6(wglUseFontBitmaps.Addr(), 4,
 		uintptr(hdc),
 		uintptr(first),
 		uintptr(count),
@@ -283,7 +284,7 @@ func WglUseFontBitmaps(hdc HDC, first, count, listbase uint32) bool {
 }
 
 func WglUseFontOutlines(hdc HDC, first, count, listbase uint32, deviation, extrusion float32, format int, pgmf *GLYPHMETRICSFLOAT) bool {
-	ret, _, _ := syscall.Syscall12(wglUseFontBitmaps, 8,
+	ret, _, _ := syscall.Syscall12(wglUseFontBitmaps.Addr(), 8,
 		uintptr(hdc),
 		uintptr(first),
 		uintptr(count),

--- a/pdh.go
+++ b/pdh.go
@@ -7,6 +7,7 @@
 package win
 
 import (
+	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
 )
@@ -161,32 +162,32 @@ type PDH_FMT_COUNTERVALUE_ITEM_LONG struct {
 
 var (
 	// Library
-	libpdhDll *syscall.DLL
+	libpdhDll *windows.LazyDLL
 
 	// Functions
-	pdh_AddCounterW               *syscall.Proc
-	pdh_AddEnglishCounterW        *syscall.Proc
-	pdh_CloseQuery                *syscall.Proc
-	pdh_CollectQueryData          *syscall.Proc
-	pdh_GetFormattedCounterValue  *syscall.Proc
-	pdh_GetFormattedCounterArrayW *syscall.Proc
-	pdh_OpenQuery                 *syscall.Proc
-	pdh_ValidatePathW             *syscall.Proc
+	pdh_AddCounterW               *windows.LazyProc
+	pdh_AddEnglishCounterW        *windows.LazyProc
+	pdh_CloseQuery                *windows.LazyProc
+	pdh_CollectQueryData          *windows.LazyProc
+	pdh_GetFormattedCounterValue  *windows.LazyProc
+	pdh_GetFormattedCounterArrayW *windows.LazyProc
+	pdh_OpenQuery                 *windows.LazyProc
+	pdh_ValidatePathW             *windows.LazyProc
 )
 
 func init() {
 	// Library
-	libpdhDll = syscall.MustLoadDLL("pdh.dll")
+	libpdhDll = windows.NewLazySystemDLL("pdh.dll")
 
 	// Functions
-	pdh_AddCounterW = libpdhDll.MustFindProc("PdhAddCounterW")
-	pdh_AddEnglishCounterW, _ = libpdhDll.FindProc("PdhAddEnglishCounterW") // XXX: only supported on versions > Vista.
-	pdh_CloseQuery = libpdhDll.MustFindProc("PdhCloseQuery")
-	pdh_CollectQueryData = libpdhDll.MustFindProc("PdhCollectQueryData")
-	pdh_GetFormattedCounterValue = libpdhDll.MustFindProc("PdhGetFormattedCounterValue")
-	pdh_GetFormattedCounterArrayW = libpdhDll.MustFindProc("PdhGetFormattedCounterArrayW")
-	pdh_OpenQuery = libpdhDll.MustFindProc("PdhOpenQuery")
-	pdh_ValidatePathW = libpdhDll.MustFindProc("PdhValidatePathW")
+	pdh_AddCounterW = libpdhDll.NewProc("PdhAddCounterW")
+	pdh_AddEnglishCounterW = libpdhDll.NewProc("PdhAddEnglishCounterW")
+	pdh_CloseQuery = libpdhDll.NewProc("PdhCloseQuery")
+	pdh_CollectQueryData = libpdhDll.NewProc("PdhCollectQueryData")
+	pdh_GetFormattedCounterValue = libpdhDll.NewProc("PdhGetFormattedCounterValue")
+	pdh_GetFormattedCounterArrayW = libpdhDll.NewProc("PdhGetFormattedCounterArrayW")
+	pdh_OpenQuery = libpdhDll.NewProc("PdhOpenQuery")
+	pdh_ValidatePathW = libpdhDll.NewProc("PdhValidatePathW")
 }
 
 // Adds the specified counter to the query. This is the internationalized version. Preferably, use the
@@ -241,7 +242,7 @@ func PdhAddCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintp
 // Adds the specified language-neutral counter to the query. See the PdhAddCounter function. This function only exists on
 // Windows versions higher than Vista.
 func PdhAddEnglishCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
-	if pdh_AddEnglishCounterW == nil {
+	if pdh_AddEnglishCounterW.Find() != nil {
 		return ERROR_INVALID_FUNCTION
 	}
 

--- a/shell32.go
+++ b/shell32.go
@@ -7,6 +7,7 @@
 package win
 
 import (
+	"golang.org/x/sys/windows"
 	"syscall"
 	"unsafe"
 )
@@ -293,40 +294,40 @@ type SHSTOCKICONINFO struct {
 
 var (
 	// Library
-	libshell32 uintptr
+	libshell32 *windows.LazyDLL
 
 	// Functions
-	dragAcceptFiles        uintptr
-	dragFinish             uintptr
-	dragQueryFile          uintptr
-	shBrowseForFolder      uintptr
-	shGetFileInfo          uintptr
-	shGetPathFromIDList    uintptr
-	shGetSpecialFolderPath uintptr
-	shParseDisplayName     uintptr
-	shGetStockIconInfo     uintptr
-	shell_NotifyIcon       uintptr
+	dragAcceptFiles        *windows.LazyProc
+	dragFinish             *windows.LazyProc
+	dragQueryFile          *windows.LazyProc
+	shBrowseForFolder      *windows.LazyProc
+	shGetFileInfo          *windows.LazyProc
+	shGetPathFromIDList    *windows.LazyProc
+	shGetSpecialFolderPath *windows.LazyProc
+	shParseDisplayName     *windows.LazyProc
+	shGetStockIconInfo     *windows.LazyProc
+	shell_NotifyIcon       *windows.LazyProc
 )
 
 func init() {
 	// Library
-	libshell32 = MustLoadLibrary("shell32.dll")
+	libshell32 = windows.NewLazySystemDLL("shell32.dll")
 
 	// Functions
-	dragAcceptFiles = MustGetProcAddress(libshell32, "DragAcceptFiles")
-	dragFinish = MustGetProcAddress(libshell32, "DragFinish")
-	dragQueryFile = MustGetProcAddress(libshell32, "DragQueryFileW")
-	shBrowseForFolder = MustGetProcAddress(libshell32, "SHBrowseForFolderW")
-	shGetFileInfo = MustGetProcAddress(libshell32, "SHGetFileInfoW")
-	shGetPathFromIDList = MustGetProcAddress(libshell32, "SHGetPathFromIDListW")
-	shGetSpecialFolderPath = MustGetProcAddress(libshell32, "SHGetSpecialFolderPathW")
-	shGetStockIconInfo = MaybeGetProcAddress(libshell32, "SHGetStockIconInfo")
-	shell_NotifyIcon = MustGetProcAddress(libshell32, "Shell_NotifyIconW")
-	shParseDisplayName = MustGetProcAddress(libshell32, "SHParseDisplayName")
+	dragAcceptFiles = libshell32.NewProc("DragAcceptFiles")
+	dragFinish = libshell32.NewProc("DragFinish")
+	dragQueryFile = libshell32.NewProc("DragQueryFileW")
+	shBrowseForFolder = libshell32.NewProc("SHBrowseForFolderW")
+	shGetFileInfo = libshell32.NewProc("SHGetFileInfoW")
+	shGetPathFromIDList = libshell32.NewProc("SHGetPathFromIDListW")
+	shGetSpecialFolderPath = libshell32.NewProc("SHGetSpecialFolderPathW")
+	shGetStockIconInfo = libshell32.NewProc("SHGetStockIconInfo")
+	shell_NotifyIcon = libshell32.NewProc("Shell_NotifyIconW")
+	shParseDisplayName = libshell32.NewProc("SHParseDisplayName")
 }
 
 func DragAcceptFiles(hWnd HWND, fAccept bool) bool {
-	ret, _, _ := syscall.Syscall(dragAcceptFiles, 2,
+	ret, _, _ := syscall.Syscall(dragAcceptFiles.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(BoolToBOOL(fAccept)),
 		0)
@@ -335,7 +336,7 @@ func DragAcceptFiles(hWnd HWND, fAccept bool) bool {
 }
 
 func DragQueryFile(hDrop HDROP, iFile uint, lpszFile *uint16, cch uint) uint {
-	ret, _, _ := syscall.Syscall6(dragQueryFile, 4,
+	ret, _, _ := syscall.Syscall6(dragQueryFile.Addr(), 4,
 		uintptr(hDrop),
 		uintptr(iFile),
 		uintptr(unsafe.Pointer(lpszFile)),
@@ -347,14 +348,14 @@ func DragQueryFile(hDrop HDROP, iFile uint, lpszFile *uint16, cch uint) uint {
 }
 
 func DragFinish(hDrop HDROP) {
-	syscall.Syscall(dragAcceptFiles, 1,
+	syscall.Syscall(dragAcceptFiles.Addr(), 1,
 		uintptr(hDrop),
 		0,
 		0)
 }
 
 func SHBrowseForFolder(lpbi *BROWSEINFO) uintptr {
-	ret, _, _ := syscall.Syscall(shBrowseForFolder, 1,
+	ret, _, _ := syscall.Syscall(shBrowseForFolder.Addr(), 1,
 		uintptr(unsafe.Pointer(lpbi)),
 		0,
 		0)
@@ -363,7 +364,7 @@ func SHBrowseForFolder(lpbi *BROWSEINFO) uintptr {
 }
 
 func SHGetFileInfo(pszPath *uint16, dwFileAttributes uint32, psfi *SHFILEINFO, cbFileInfo, uFlags uint32) uintptr {
-	ret, _, _ := syscall.Syscall6(shGetFileInfo, 5,
+	ret, _, _ := syscall.Syscall6(shGetFileInfo.Addr(), 5,
 		uintptr(unsafe.Pointer(pszPath)),
 		uintptr(dwFileAttributes),
 		uintptr(unsafe.Pointer(psfi)),
@@ -375,7 +376,7 @@ func SHGetFileInfo(pszPath *uint16, dwFileAttributes uint32, psfi *SHFILEINFO, c
 }
 
 func SHGetPathFromIDList(pidl uintptr, pszPath *uint16) bool {
-	ret, _, _ := syscall.Syscall(shGetPathFromIDList, 2,
+	ret, _, _ := syscall.Syscall(shGetPathFromIDList.Addr(), 2,
 		pidl,
 		uintptr(unsafe.Pointer(pszPath)),
 		0)
@@ -384,7 +385,7 @@ func SHGetPathFromIDList(pidl uintptr, pszPath *uint16) bool {
 }
 
 func SHGetSpecialFolderPath(hwndOwner HWND, lpszPath *uint16, csidl CSIDL, fCreate bool) bool {
-	ret, _, _ := syscall.Syscall6(shGetSpecialFolderPath, 4,
+	ret, _, _ := syscall.Syscall6(shGetSpecialFolderPath.Addr(), 4,
 		uintptr(hwndOwner),
 		uintptr(unsafe.Pointer(lpszPath)),
 		uintptr(csidl),
@@ -396,7 +397,7 @@ func SHGetSpecialFolderPath(hwndOwner HWND, lpszPath *uint16, csidl CSIDL, fCrea
 }
 
 func SHParseDisplayName(pszName *uint16, pbc uintptr, ppidl *uintptr, sfgaoIn uint32, psfgaoOut *uint32) HRESULT {
-	ret, _, _ := syscall.Syscall6(shParseDisplayName, 5,
+	ret, _, _ := syscall.Syscall6(shParseDisplayName.Addr(), 5,
 		uintptr(unsafe.Pointer(pszName)),
 		pbc,
 		uintptr(unsafe.Pointer(ppidl)),
@@ -408,7 +409,10 @@ func SHParseDisplayName(pszName *uint16, pbc uintptr, ppidl *uintptr, sfgaoIn ui
 }
 
 func SHGetStockIconInfo(stockIconId int32, uFlags uint32, stockIcon *SHSTOCKICONINFO) HRESULT {
-	ret, _, _ := syscall.Syscall6(shGetStockIconInfo, 3,
+	if shGetStockIconInfo.Find() != nil {
+		return HRESULT(0)
+	}
+	ret, _, _ := syscall.Syscall6(shGetStockIconInfo.Addr(), 3,
 		uintptr(stockIconId),
 		uintptr(uFlags),
 		uintptr(unsafe.Pointer(stockIcon)),
@@ -420,7 +424,7 @@ func SHGetStockIconInfo(stockIconId int32, uFlags uint32, stockIcon *SHSTOCKICON
 }
 
 func Shell_NotifyIcon(dwMessage uint32, lpdata *NOTIFYICONDATA) bool {
-	ret, _, _ := syscall.Syscall(shell_NotifyIcon, 2,
+	ret, _, _ := syscall.Syscall(shell_NotifyIcon.Addr(), 2,
 		uintptr(dwMessage),
 		uintptr(unsafe.Pointer(lpdata)),
 		0)

--- a/user32.go
+++ b/user32.go
@@ -1592,270 +1592,270 @@ func GET_Y_LPARAM(lp uintptr) int32 {
 
 var (
 	// Library
-	libuser32 uintptr
+	libuser32 *windows.LazyDLL
 
 	// Functions
-	addClipboardFormatListener uintptr
-	adjustWindowRect           uintptr
-	animateWindow              uintptr
-	beginDeferWindowPos        uintptr
-	beginPaint                 uintptr
-	callWindowProc             uintptr
-	checkMenuRadioItem         uintptr
-	clientToScreen             uintptr
-	closeClipboard             uintptr
-	createDialogParam          uintptr
-	createIconIndirect         uintptr
-	createMenu                 uintptr
-	createPopupMenu            uintptr
-	createWindowEx             uintptr
-	deferWindowPos             uintptr
-	defWindowProc              uintptr
-	destroyIcon                uintptr
-	destroyMenu                uintptr
-	destroyWindow              uintptr
-	dialogBoxParam             uintptr
-	dispatchMessage            uintptr
-	drawIconEx                 uintptr
-	drawMenuBar                uintptr
-	drawFocusRect              uintptr
-	drawTextEx                 uintptr
-	emptyClipboard             uintptr
-	enableWindow               uintptr
-	endDeferWindowPos          uintptr
-	endDialog                  uintptr
-	endPaint                   uintptr
-	enumChildWindows           uintptr
-	findWindow                 uintptr
-	getActiveWindow            uintptr
-	getAncestor                uintptr
-	getCaretPos                uintptr
-	getClassName               uintptr
-	getClientRect              uintptr
-	getClipboardData           uintptr
-	getCursorPos               uintptr
-	getDC                      uintptr
-	getDesktopWindow           uintptr
-	getFocus                   uintptr
-	getForegroundWindow        uintptr
-	getKeyState                uintptr
-	getMenuInfo                uintptr
-	getMessage                 uintptr
-	getMonitorInfo             uintptr
-	getParent                  uintptr
-	getRawInputData            uintptr
-	getScrollInfo              uintptr
-	getSysColor                uintptr
-	getSysColorBrush           uintptr
-	getSystemMetrics           uintptr
-	getWindow                  uintptr
-	getWindowLong              uintptr
-	getWindowLongPtr           uintptr
-	getWindowPlacement         uintptr
-	getWindowRect              uintptr
-	insertMenuItem             uintptr
-	invalidateRect             uintptr
-	isChild                    uintptr
-	isClipboardFormatAvailable uintptr
-	isDialogMessage            uintptr
-	isWindowEnabled            uintptr
-	isWindowVisible            uintptr
-	killTimer                  uintptr
-	loadCursor                 uintptr
-	loadIcon                   uintptr
-	loadImage                  uintptr
-	loadMenu                   uintptr
-	loadString                 uintptr
-	messageBeep                uintptr
-	messageBox                 uintptr
-	monitorFromWindow          uintptr
-	moveWindow                 uintptr
-	unregisterClass            uintptr
-	openClipboard              uintptr
-	peekMessage                uintptr
-	postMessage                uintptr
-	postQuitMessage            uintptr
-	registerClassEx            uintptr
-	registerRawInputDevices    uintptr
-	registerWindowMessage      uintptr
-	releaseCapture             uintptr
-	releaseDC                  uintptr
-	removeMenu                 uintptr
-	screenToClient             uintptr
-	sendDlgItemMessage         uintptr
-	sendInput                  uintptr
-	sendMessage                uintptr
-	setActiveWindow            uintptr
-	setCapture                 uintptr
-	setClipboardData           uintptr
-	setCursor                  uintptr
-	setCursorPos               uintptr
-	setFocus                   uintptr
-	setForegroundWindow        uintptr
-	setMenu                    uintptr
-	setMenuInfo                uintptr
-	setMenuItemInfo            uintptr
-	setParent                  uintptr
-	setRect                    uintptr
-	setScrollInfo              uintptr
-	setTimer                   uintptr
-	setWinEventHook            uintptr
-	setWindowLong              uintptr
-	setWindowLongPtr           uintptr
-	setWindowPlacement         uintptr
-	setWindowPos               uintptr
-	showWindow                 uintptr
-	systemParametersInfo       uintptr
-	trackPopupMenuEx           uintptr
-	translateMessage           uintptr
-	unhookWinEvent             uintptr
-	updateWindow               uintptr
-	windowFromDC               uintptr
-	windowFromPoint            uintptr
+	addClipboardFormatListener *windows.LazyProc
+	adjustWindowRect           *windows.LazyProc
+	animateWindow              *windows.LazyProc
+	beginDeferWindowPos        *windows.LazyProc
+	beginPaint                 *windows.LazyProc
+	callWindowProc             *windows.LazyProc
+	checkMenuRadioItem         *windows.LazyProc
+	clientToScreen             *windows.LazyProc
+	closeClipboard             *windows.LazyProc
+	createDialogParam          *windows.LazyProc
+	createIconIndirect         *windows.LazyProc
+	createMenu                 *windows.LazyProc
+	createPopupMenu            *windows.LazyProc
+	createWindowEx             *windows.LazyProc
+	deferWindowPos             *windows.LazyProc
+	defWindowProc              *windows.LazyProc
+	destroyIcon                *windows.LazyProc
+	destroyMenu                *windows.LazyProc
+	destroyWindow              *windows.LazyProc
+	dialogBoxParam             *windows.LazyProc
+	dispatchMessage            *windows.LazyProc
+	drawIconEx                 *windows.LazyProc
+	drawMenuBar                *windows.LazyProc
+	drawFocusRect              *windows.LazyProc
+	drawTextEx                 *windows.LazyProc
+	emptyClipboard             *windows.LazyProc
+	enableWindow               *windows.LazyProc
+	endDeferWindowPos          *windows.LazyProc
+	endDialog                  *windows.LazyProc
+	endPaint                   *windows.LazyProc
+	enumChildWindows           *windows.LazyProc
+	findWindow                 *windows.LazyProc
+	getActiveWindow            *windows.LazyProc
+	getAncestor                *windows.LazyProc
+	getCaretPos                *windows.LazyProc
+	getClassName               *windows.LazyProc
+	getClientRect              *windows.LazyProc
+	getClipboardData           *windows.LazyProc
+	getCursorPos               *windows.LazyProc
+	getDC                      *windows.LazyProc
+	getDesktopWindow           *windows.LazyProc
+	getFocus                   *windows.LazyProc
+	getForegroundWindow        *windows.LazyProc
+	getKeyState                *windows.LazyProc
+	getMenuInfo                *windows.LazyProc
+	getMessage                 *windows.LazyProc
+	getMonitorInfo             *windows.LazyProc
+	getParent                  *windows.LazyProc
+	getRawInputData            *windows.LazyProc
+	getScrollInfo              *windows.LazyProc
+	getSysColor                *windows.LazyProc
+	getSysColorBrush           *windows.LazyProc
+	getSystemMetrics           *windows.LazyProc
+	getWindow                  *windows.LazyProc
+	getWindowLong              *windows.LazyProc
+	getWindowLongPtr           *windows.LazyProc
+	getWindowPlacement         *windows.LazyProc
+	getWindowRect              *windows.LazyProc
+	insertMenuItem             *windows.LazyProc
+	invalidateRect             *windows.LazyProc
+	isChild                    *windows.LazyProc
+	isClipboardFormatAvailable *windows.LazyProc
+	isDialogMessage            *windows.LazyProc
+	isWindowEnabled            *windows.LazyProc
+	isWindowVisible            *windows.LazyProc
+	killTimer                  *windows.LazyProc
+	loadCursor                 *windows.LazyProc
+	loadIcon                   *windows.LazyProc
+	loadImage                  *windows.LazyProc
+	loadMenu                   *windows.LazyProc
+	loadString                 *windows.LazyProc
+	messageBeep                *windows.LazyProc
+	messageBox                 *windows.LazyProc
+	monitorFromWindow          *windows.LazyProc
+	moveWindow                 *windows.LazyProc
+	unregisterClass            *windows.LazyProc
+	openClipboard              *windows.LazyProc
+	peekMessage                *windows.LazyProc
+	postMessage                *windows.LazyProc
+	postQuitMessage            *windows.LazyProc
+	registerClassEx            *windows.LazyProc
+	registerRawInputDevices    *windows.LazyProc
+	registerWindowMessage      *windows.LazyProc
+	releaseCapture             *windows.LazyProc
+	releaseDC                  *windows.LazyProc
+	removeMenu                 *windows.LazyProc
+	screenToClient             *windows.LazyProc
+	sendDlgItemMessage         *windows.LazyProc
+	sendInput                  *windows.LazyProc
+	sendMessage                *windows.LazyProc
+	setActiveWindow            *windows.LazyProc
+	setCapture                 *windows.LazyProc
+	setClipboardData           *windows.LazyProc
+	setCursor                  *windows.LazyProc
+	setCursorPos               *windows.LazyProc
+	setFocus                   *windows.LazyProc
+	setForegroundWindow        *windows.LazyProc
+	setMenu                    *windows.LazyProc
+	setMenuInfo                *windows.LazyProc
+	setMenuItemInfo            *windows.LazyProc
+	setParent                  *windows.LazyProc
+	setRect                    *windows.LazyProc
+	setScrollInfo              *windows.LazyProc
+	setTimer                   *windows.LazyProc
+	setWinEventHook            *windows.LazyProc
+	setWindowLong              *windows.LazyProc
+	setWindowLongPtr           *windows.LazyProc
+	setWindowPlacement         *windows.LazyProc
+	setWindowPos               *windows.LazyProc
+	showWindow                 *windows.LazyProc
+	systemParametersInfo       *windows.LazyProc
+	trackPopupMenuEx           *windows.LazyProc
+	translateMessage           *windows.LazyProc
+	unhookWinEvent             *windows.LazyProc
+	updateWindow               *windows.LazyProc
+	windowFromDC               *windows.LazyProc
+	windowFromPoint            *windows.LazyProc
 )
 
 func init() {
 	is64bit := unsafe.Sizeof(uintptr(0)) == 8
 
 	// Library
-	libuser32 = MustLoadLibrary("user32.dll")
+	libuser32 = windows.NewLazySystemDLL("user32.dll")
 
 	// Functions
-	addClipboardFormatListener, _ = syscall.GetProcAddress(syscall.Handle(libuser32), "AddClipboardFormatListener")
-	adjustWindowRect = MustGetProcAddress(libuser32, "AdjustWindowRect")
-	animateWindow = MustGetProcAddress(libuser32, "AnimateWindow")
-	beginDeferWindowPos = MustGetProcAddress(libuser32, "BeginDeferWindowPos")
-	beginPaint = MustGetProcAddress(libuser32, "BeginPaint")
-	callWindowProc = MustGetProcAddress(libuser32, "CallWindowProcW")
-	checkMenuRadioItem = MustGetProcAddress(libuser32, "CheckMenuRadioItem")
-	clientToScreen = MustGetProcAddress(libuser32, "ClientToScreen")
-	closeClipboard = MustGetProcAddress(libuser32, "CloseClipboard")
-	createDialogParam = MustGetProcAddress(libuser32, "CreateDialogParamW")
-	createIconIndirect = MustGetProcAddress(libuser32, "CreateIconIndirect")
-	createMenu = MustGetProcAddress(libuser32, "CreateMenu")
-	createPopupMenu = MustGetProcAddress(libuser32, "CreatePopupMenu")
-	createWindowEx = MustGetProcAddress(libuser32, "CreateWindowExW")
-	deferWindowPos = MustGetProcAddress(libuser32, "DeferWindowPos")
-	defWindowProc = MustGetProcAddress(libuser32, "DefWindowProcW")
-	destroyIcon = MustGetProcAddress(libuser32, "DestroyIcon")
-	destroyMenu = MustGetProcAddress(libuser32, "DestroyMenu")
-	destroyWindow = MustGetProcAddress(libuser32, "DestroyWindow")
-	dialogBoxParam = MustGetProcAddress(libuser32, "DialogBoxParamW")
-	dispatchMessage = MustGetProcAddress(libuser32, "DispatchMessageW")
-	drawIconEx = MustGetProcAddress(libuser32, "DrawIconEx")
-	drawFocusRect = MustGetProcAddress(libuser32, "DrawFocusRect")
-	drawMenuBar = MustGetProcAddress(libuser32, "DrawMenuBar")
-	drawTextEx = MustGetProcAddress(libuser32, "DrawTextExW")
-	emptyClipboard = MustGetProcAddress(libuser32, "EmptyClipboard")
-	enableWindow = MustGetProcAddress(libuser32, "EnableWindow")
-	endDeferWindowPos = MustGetProcAddress(libuser32, "EndDeferWindowPos")
-	endDialog = MustGetProcAddress(libuser32, "EndDialog")
-	endPaint = MustGetProcAddress(libuser32, "EndPaint")
-	enumChildWindows = MustGetProcAddress(libuser32, "EnumChildWindows")
-	findWindow = MustGetProcAddress(libuser32, "FindWindowW")
-	getActiveWindow = MustGetProcAddress(libuser32, "GetActiveWindow")
-	getAncestor = MustGetProcAddress(libuser32, "GetAncestor")
-	getCaretPos = MustGetProcAddress(libuser32, "GetCaretPos")
-	getClassName = MustGetProcAddress(libuser32, "GetClassNameW")
-	getClientRect = MustGetProcAddress(libuser32, "GetClientRect")
-	getClipboardData = MustGetProcAddress(libuser32, "GetClipboardData")
-	getCursorPos = MustGetProcAddress(libuser32, "GetCursorPos")
-	getDC = MustGetProcAddress(libuser32, "GetDC")
-	getDesktopWindow = MustGetProcAddress(libuser32, "GetDesktopWindow")
-	getFocus = MustGetProcAddress(libuser32, "GetFocus")
-	getForegroundWindow = MustGetProcAddress(libuser32, "GetForegroundWindow")
-	getKeyState = MustGetProcAddress(libuser32, "GetKeyState")
-	getMenuInfo = MustGetProcAddress(libuser32, "GetMenuInfo")
-	getMessage = MustGetProcAddress(libuser32, "GetMessageW")
-	getMonitorInfo = MustGetProcAddress(libuser32, "GetMonitorInfoW")
-	getParent = MustGetProcAddress(libuser32, "GetParent")
-	getRawInputData = MustGetProcAddress(libuser32, "GetRawInputData")
-	getScrollInfo = MustGetProcAddress(libuser32, "GetScrollInfo")
-	getSysColor = MustGetProcAddress(libuser32, "GetSysColor")
-	getSysColorBrush = MustGetProcAddress(libuser32, "GetSysColorBrush")
-	getSystemMetrics = MustGetProcAddress(libuser32, "GetSystemMetrics")
-	getWindow = MustGetProcAddress(libuser32, "GetWindow")
-	getWindowLong = MustGetProcAddress(libuser32, "GetWindowLongW")
+	addClipboardFormatListener = libuser32.NewProc("AddClipboardFormatListener")
+	adjustWindowRect = libuser32.NewProc("AdjustWindowRect")
+	animateWindow = libuser32.NewProc("AnimateWindow")
+	beginDeferWindowPos = libuser32.NewProc("BeginDeferWindowPos")
+	beginPaint = libuser32.NewProc("BeginPaint")
+	callWindowProc = libuser32.NewProc("CallWindowProcW")
+	checkMenuRadioItem = libuser32.NewProc("CheckMenuRadioItem")
+	clientToScreen = libuser32.NewProc("ClientToScreen")
+	closeClipboard = libuser32.NewProc("CloseClipboard")
+	createDialogParam = libuser32.NewProc("CreateDialogParamW")
+	createIconIndirect = libuser32.NewProc("CreateIconIndirect")
+	createMenu = libuser32.NewProc("CreateMenu")
+	createPopupMenu = libuser32.NewProc("CreatePopupMenu")
+	createWindowEx = libuser32.NewProc("CreateWindowExW")
+	deferWindowPos = libuser32.NewProc("DeferWindowPos")
+	defWindowProc = libuser32.NewProc("DefWindowProcW")
+	destroyIcon = libuser32.NewProc("DestroyIcon")
+	destroyMenu = libuser32.NewProc("DestroyMenu")
+	destroyWindow = libuser32.NewProc("DestroyWindow")
+	dialogBoxParam = libuser32.NewProc("DialogBoxParamW")
+	dispatchMessage = libuser32.NewProc("DispatchMessageW")
+	drawIconEx = libuser32.NewProc("DrawIconEx")
+	drawFocusRect = libuser32.NewProc("DrawFocusRect")
+	drawMenuBar = libuser32.NewProc("DrawMenuBar")
+	drawTextEx = libuser32.NewProc("DrawTextExW")
+	emptyClipboard = libuser32.NewProc("EmptyClipboard")
+	enableWindow = libuser32.NewProc("EnableWindow")
+	endDeferWindowPos = libuser32.NewProc("EndDeferWindowPos")
+	endDialog = libuser32.NewProc("EndDialog")
+	endPaint = libuser32.NewProc("EndPaint")
+	enumChildWindows = libuser32.NewProc("EnumChildWindows")
+	findWindow = libuser32.NewProc("FindWindowW")
+	getActiveWindow = libuser32.NewProc("GetActiveWindow")
+	getAncestor = libuser32.NewProc("GetAncestor")
+	getCaretPos = libuser32.NewProc("GetCaretPos")
+	getClassName = libuser32.NewProc("GetClassNameW")
+	getClientRect = libuser32.NewProc("GetClientRect")
+	getClipboardData = libuser32.NewProc("GetClipboardData")
+	getCursorPos = libuser32.NewProc("GetCursorPos")
+	getDC = libuser32.NewProc("GetDC")
+	getDesktopWindow = libuser32.NewProc("GetDesktopWindow")
+	getFocus = libuser32.NewProc("GetFocus")
+	getForegroundWindow = libuser32.NewProc("GetForegroundWindow")
+	getKeyState = libuser32.NewProc("GetKeyState")
+	getMenuInfo = libuser32.NewProc("GetMenuInfo")
+	getMessage = libuser32.NewProc("GetMessageW")
+	getMonitorInfo = libuser32.NewProc("GetMonitorInfoW")
+	getParent = libuser32.NewProc("GetParent")
+	getRawInputData = libuser32.NewProc("GetRawInputData")
+	getScrollInfo = libuser32.NewProc("GetScrollInfo")
+	getSysColor = libuser32.NewProc("GetSysColor")
+	getSysColorBrush = libuser32.NewProc("GetSysColorBrush")
+	getSystemMetrics = libuser32.NewProc("GetSystemMetrics")
+	getWindow = libuser32.NewProc("GetWindow")
+	getWindowLong = libuser32.NewProc("GetWindowLongW")
 	// On 32 bit GetWindowLongPtrW is not available
 	if is64bit {
-		getWindowLongPtr = MustGetProcAddress(libuser32, "GetWindowLongPtrW")
+		getWindowLongPtr = libuser32.NewProc("GetWindowLongPtrW")
 	} else {
-		getWindowLongPtr = MustGetProcAddress(libuser32, "GetWindowLongW")
+		getWindowLongPtr = libuser32.NewProc("GetWindowLongW")
 	}
-	getWindowPlacement = MustGetProcAddress(libuser32, "GetWindowPlacement")
-	getWindowRect = MustGetProcAddress(libuser32, "GetWindowRect")
-	insertMenuItem = MustGetProcAddress(libuser32, "InsertMenuItemW")
-	invalidateRect = MustGetProcAddress(libuser32, "InvalidateRect")
-	isChild = MustGetProcAddress(libuser32, "IsChild")
-	isClipboardFormatAvailable = MustGetProcAddress(libuser32, "IsClipboardFormatAvailable")
-	isDialogMessage = MustGetProcAddress(libuser32, "IsDialogMessageW")
-	isWindowEnabled = MustGetProcAddress(libuser32, "IsWindowEnabled")
-	isWindowVisible = MustGetProcAddress(libuser32, "IsWindowVisible")
-	killTimer = MustGetProcAddress(libuser32, "KillTimer")
-	loadCursor = MustGetProcAddress(libuser32, "LoadCursorW")
-	loadIcon = MustGetProcAddress(libuser32, "LoadIconW")
-	loadImage = MustGetProcAddress(libuser32, "LoadImageW")
-	loadMenu = MustGetProcAddress(libuser32, "LoadMenuW")
-	loadString = MustGetProcAddress(libuser32, "LoadStringW")
-	messageBeep = MustGetProcAddress(libuser32, "MessageBeep")
-	messageBox = MustGetProcAddress(libuser32, "MessageBoxW")
-	monitorFromWindow = MustGetProcAddress(libuser32, "MonitorFromWindow")
-	moveWindow = MustGetProcAddress(libuser32, "MoveWindow")
-	unregisterClass = MustGetProcAddress(libuser32, "UnregisterClassW")
-	openClipboard = MustGetProcAddress(libuser32, "OpenClipboard")
-	peekMessage = MustGetProcAddress(libuser32, "PeekMessageW")
-	postMessage = MustGetProcAddress(libuser32, "PostMessageW")
-	postQuitMessage = MustGetProcAddress(libuser32, "PostQuitMessage")
-	registerClassEx = MustGetProcAddress(libuser32, "RegisterClassExW")
-	registerRawInputDevices = MustGetProcAddress(libuser32, "RegisterRawInputDevices")
-	registerWindowMessage = MustGetProcAddress(libuser32, "RegisterWindowMessageW")
-	releaseCapture = MustGetProcAddress(libuser32, "ReleaseCapture")
-	releaseDC = MustGetProcAddress(libuser32, "ReleaseDC")
-	removeMenu = MustGetProcAddress(libuser32, "RemoveMenu")
-	screenToClient = MustGetProcAddress(libuser32, "ScreenToClient")
-	sendDlgItemMessage = MustGetProcAddress(libuser32, "SendDlgItemMessageW")
-	sendInput = MustGetProcAddress(libuser32, "SendInput")
-	sendMessage = MustGetProcAddress(libuser32, "SendMessageW")
-	setActiveWindow = MustGetProcAddress(libuser32, "SetActiveWindow")
-	setCapture = MustGetProcAddress(libuser32, "SetCapture")
-	setClipboardData = MustGetProcAddress(libuser32, "SetClipboardData")
-	setCursor = MustGetProcAddress(libuser32, "SetCursor")
-	setCursorPos = MustGetProcAddress(libuser32, "SetCursorPos")
-	setFocus = MustGetProcAddress(libuser32, "SetFocus")
-	setForegroundWindow = MustGetProcAddress(libuser32, "SetForegroundWindow")
-	setMenu = MustGetProcAddress(libuser32, "SetMenu")
-	setMenuInfo = MustGetProcAddress(libuser32, "SetMenuInfo")
-	setMenuItemInfo = MustGetProcAddress(libuser32, "SetMenuItemInfoW")
-	setRect = MustGetProcAddress(libuser32, "SetRect")
-	setParent = MustGetProcAddress(libuser32, "SetParent")
-	setScrollInfo = MustGetProcAddress(libuser32, "SetScrollInfo")
-	setTimer = MustGetProcAddress(libuser32, "SetTimer")
-	setWinEventHook = MustGetProcAddress(libuser32, "SetWinEventHook")
-	setWindowLong = MustGetProcAddress(libuser32, "SetWindowLongW")
+	getWindowPlacement = libuser32.NewProc("GetWindowPlacement")
+	getWindowRect = libuser32.NewProc("GetWindowRect")
+	insertMenuItem = libuser32.NewProc("InsertMenuItemW")
+	invalidateRect = libuser32.NewProc("InvalidateRect")
+	isChild = libuser32.NewProc("IsChild")
+	isClipboardFormatAvailable = libuser32.NewProc("IsClipboardFormatAvailable")
+	isDialogMessage = libuser32.NewProc("IsDialogMessageW")
+	isWindowEnabled = libuser32.NewProc("IsWindowEnabled")
+	isWindowVisible = libuser32.NewProc("IsWindowVisible")
+	killTimer = libuser32.NewProc("KillTimer")
+	loadCursor = libuser32.NewProc("LoadCursorW")
+	loadIcon = libuser32.NewProc("LoadIconW")
+	loadImage = libuser32.NewProc("LoadImageW")
+	loadMenu = libuser32.NewProc("LoadMenuW")
+	loadString = libuser32.NewProc("LoadStringW")
+	messageBeep = libuser32.NewProc("MessageBeep")
+	messageBox = libuser32.NewProc("MessageBoxW")
+	monitorFromWindow = libuser32.NewProc("MonitorFromWindow")
+	moveWindow = libuser32.NewProc("MoveWindow")
+	unregisterClass = libuser32.NewProc("UnregisterClassW")
+	openClipboard = libuser32.NewProc("OpenClipboard")
+	peekMessage = libuser32.NewProc("PeekMessageW")
+	postMessage = libuser32.NewProc("PostMessageW")
+	postQuitMessage = libuser32.NewProc("PostQuitMessage")
+	registerClassEx = libuser32.NewProc("RegisterClassExW")
+	registerRawInputDevices = libuser32.NewProc("RegisterRawInputDevices")
+	registerWindowMessage = libuser32.NewProc("RegisterWindowMessageW")
+	releaseCapture = libuser32.NewProc("ReleaseCapture")
+	releaseDC = libuser32.NewProc("ReleaseDC")
+	removeMenu = libuser32.NewProc("RemoveMenu")
+	screenToClient = libuser32.NewProc("ScreenToClient")
+	sendDlgItemMessage = libuser32.NewProc("SendDlgItemMessageW")
+	sendInput = libuser32.NewProc("SendInput")
+	sendMessage = libuser32.NewProc("SendMessageW")
+	setActiveWindow = libuser32.NewProc("SetActiveWindow")
+	setCapture = libuser32.NewProc("SetCapture")
+	setClipboardData = libuser32.NewProc("SetClipboardData")
+	setCursor = libuser32.NewProc("SetCursor")
+	setCursorPos = libuser32.NewProc("SetCursorPos")
+	setFocus = libuser32.NewProc("SetFocus")
+	setForegroundWindow = libuser32.NewProc("SetForegroundWindow")
+	setMenu = libuser32.NewProc("SetMenu")
+	setMenuInfo = libuser32.NewProc("SetMenuInfo")
+	setMenuItemInfo = libuser32.NewProc("SetMenuItemInfoW")
+	setRect = libuser32.NewProc("SetRect")
+	setParent = libuser32.NewProc("SetParent")
+	setScrollInfo = libuser32.NewProc("SetScrollInfo")
+	setTimer = libuser32.NewProc("SetTimer")
+	setWinEventHook = libuser32.NewProc("SetWinEventHook")
+	setWindowLong = libuser32.NewProc("SetWindowLongW")
 	// On 32 bit SetWindowLongPtrW is not available
 	if is64bit {
-		setWindowLongPtr = MustGetProcAddress(libuser32, "SetWindowLongPtrW")
+		setWindowLongPtr = libuser32.NewProc("SetWindowLongPtrW")
 	} else {
-		setWindowLongPtr = MustGetProcAddress(libuser32, "SetWindowLongW")
+		setWindowLongPtr = libuser32.NewProc("SetWindowLongW")
 	}
-	setWindowPlacement = MustGetProcAddress(libuser32, "SetWindowPlacement")
-	setWindowPos = MustGetProcAddress(libuser32, "SetWindowPos")
-	showWindow = MustGetProcAddress(libuser32, "ShowWindow")
-	systemParametersInfo = MustGetProcAddress(libuser32, "SystemParametersInfoW")
-	trackPopupMenuEx = MustGetProcAddress(libuser32, "TrackPopupMenuEx")
-	translateMessage = MustGetProcAddress(libuser32, "TranslateMessage")
-	unhookWinEvent = MustGetProcAddress(libuser32, "UnhookWinEvent")
-	updateWindow = MustGetProcAddress(libuser32, "UpdateWindow")
-	windowFromDC = MustGetProcAddress(libuser32, "WindowFromDC")
-	windowFromPoint = MustGetProcAddress(libuser32, "WindowFromPoint")
+	setWindowPlacement = libuser32.NewProc("SetWindowPlacement")
+	setWindowPos = libuser32.NewProc("SetWindowPos")
+	showWindow = libuser32.NewProc("ShowWindow")
+	systemParametersInfo = libuser32.NewProc("SystemParametersInfoW")
+	trackPopupMenuEx = libuser32.NewProc("TrackPopupMenuEx")
+	translateMessage = libuser32.NewProc("TranslateMessage")
+	unhookWinEvent = libuser32.NewProc("UnhookWinEvent")
+	updateWindow = libuser32.NewProc("UpdateWindow")
+	windowFromDC = libuser32.NewProc("WindowFromDC")
+	windowFromPoint = libuser32.NewProc("WindowFromPoint")
 }
 
 func AddClipboardFormatListener(hwnd HWND) bool {
-	if addClipboardFormatListener == 0 {
+	if addClipboardFormatListener.Find() != nil {
 		return false
 	}
 
-	ret, _, _ := syscall.Syscall(addClipboardFormatListener, 1,
+	ret, _, _ := syscall.Syscall(addClipboardFormatListener.Addr(), 1,
 		uintptr(hwnd),
 		0,
 		0)
@@ -1864,7 +1864,7 @@ func AddClipboardFormatListener(hwnd HWND) bool {
 }
 
 func AdjustWindowRect(lpRect *RECT, dwStyle uint32, bMenu bool) bool {
-	ret, _, _ := syscall.Syscall(adjustWindowRect, 3,
+	ret, _, _ := syscall.Syscall(adjustWindowRect.Addr(), 3,
 		uintptr(unsafe.Pointer(lpRect)),
 		uintptr(dwStyle),
 		uintptr(BoolToBOOL(bMenu)))
@@ -1873,7 +1873,7 @@ func AdjustWindowRect(lpRect *RECT, dwStyle uint32, bMenu bool) bool {
 }
 
 func AnimateWindow(hwnd HWND, dwTime, dwFlags uint32) bool {
-	ret, _, _ := syscall.Syscall(animateWindow, 3,
+	ret, _, _ := syscall.Syscall(animateWindow.Addr(), 3,
 		uintptr(hwnd),
 		uintptr(dwTime),
 		uintptr(dwFlags))
@@ -1882,7 +1882,7 @@ func AnimateWindow(hwnd HWND, dwTime, dwFlags uint32) bool {
 }
 
 func BeginDeferWindowPos(nNumWindows int32) HDWP {
-	ret, _, _ := syscall.Syscall(beginDeferWindowPos, 1,
+	ret, _, _ := syscall.Syscall(beginDeferWindowPos.Addr(), 1,
 		uintptr(nNumWindows),
 		0,
 		0)
@@ -1891,7 +1891,7 @@ func BeginDeferWindowPos(nNumWindows int32) HDWP {
 }
 
 func BeginPaint(hwnd HWND, lpPaint *PAINTSTRUCT) HDC {
-	ret, _, _ := syscall.Syscall(beginPaint, 2,
+	ret, _, _ := syscall.Syscall(beginPaint.Addr(), 2,
 		uintptr(hwnd),
 		uintptr(unsafe.Pointer(lpPaint)),
 		0)
@@ -1900,7 +1900,7 @@ func BeginPaint(hwnd HWND, lpPaint *PAINTSTRUCT) HDC {
 }
 
 func CallWindowProc(lpPrevWndFunc uintptr, hWnd HWND, Msg uint32, wParam, lParam uintptr) uintptr {
-	ret, _, _ := syscall.Syscall6(callWindowProc, 5,
+	ret, _, _ := syscall.Syscall6(callWindowProc.Addr(), 5,
 		lpPrevWndFunc,
 		uintptr(hWnd),
 		uintptr(Msg),
@@ -1912,7 +1912,7 @@ func CallWindowProc(lpPrevWndFunc uintptr, hWnd HWND, Msg uint32, wParam, lParam
 }
 
 func CheckMenuRadioItem(hmenu HMENU, first, last, check, flags uint32) bool {
-	ret, _, _ := syscall.Syscall6(checkMenuRadioItem, 5,
+	ret, _, _ := syscall.Syscall6(checkMenuRadioItem.Addr(), 5,
 		uintptr(hmenu),
 		uintptr(first),
 		uintptr(last),
@@ -1924,7 +1924,7 @@ func CheckMenuRadioItem(hmenu HMENU, first, last, check, flags uint32) bool {
 }
 
 func ClientToScreen(hwnd HWND, lpPoint *POINT) bool {
-	ret, _, _ := syscall.Syscall(clientToScreen, 2,
+	ret, _, _ := syscall.Syscall(clientToScreen.Addr(), 2,
 		uintptr(hwnd),
 		uintptr(unsafe.Pointer(lpPoint)),
 		0)
@@ -1933,7 +1933,7 @@ func ClientToScreen(hwnd HWND, lpPoint *POINT) bool {
 }
 
 func CloseClipboard() bool {
-	ret, _, _ := syscall.Syscall(closeClipboard, 0,
+	ret, _, _ := syscall.Syscall(closeClipboard.Addr(), 0,
 		0,
 		0,
 		0)
@@ -1943,7 +1943,7 @@ func CloseClipboard() bool {
 
 func CreateDialogParam(instRes HINSTANCE, name *uint16, parent HWND,
 	proc, param uintptr) HWND {
-	ret, _, _ := syscall.Syscall6(createDialogParam, 5,
+	ret, _, _ := syscall.Syscall6(createDialogParam.Addr(), 5,
 		uintptr(instRes),
 		uintptr(unsafe.Pointer(name)),
 		uintptr(parent),
@@ -1955,7 +1955,7 @@ func CreateDialogParam(instRes HINSTANCE, name *uint16, parent HWND,
 }
 
 func CreateIconIndirect(lpiconinfo *ICONINFO) HICON {
-	ret, _, _ := syscall.Syscall(createIconIndirect, 1,
+	ret, _, _ := syscall.Syscall(createIconIndirect.Addr(), 1,
 		uintptr(unsafe.Pointer(lpiconinfo)),
 		0,
 		0)
@@ -1964,7 +1964,7 @@ func CreateIconIndirect(lpiconinfo *ICONINFO) HICON {
 }
 
 func CreateMenu() HMENU {
-	ret, _, _ := syscall.Syscall(createMenu, 0,
+	ret, _, _ := syscall.Syscall(createMenu.Addr(), 0,
 		0,
 		0,
 		0)
@@ -1973,7 +1973,7 @@ func CreateMenu() HMENU {
 }
 
 func CreatePopupMenu() HMENU {
-	ret, _, _ := syscall.Syscall(createPopupMenu, 0,
+	ret, _, _ := syscall.Syscall(createPopupMenu.Addr(), 0,
 		0,
 		0,
 		0)
@@ -1982,7 +1982,7 @@ func CreatePopupMenu() HMENU {
 }
 
 func CreateWindowEx(dwExStyle uint32, lpClassName, lpWindowName *uint16, dwStyle uint32, x, y, nWidth, nHeight int32, hWndParent HWND, hMenu HMENU, hInstance HINSTANCE, lpParam unsafe.Pointer) HWND {
-	ret, _, _ := syscall.Syscall12(createWindowEx, 12,
+	ret, _, _ := syscall.Syscall12(createWindowEx.Addr(), 12,
 		uintptr(dwExStyle),
 		uintptr(unsafe.Pointer(lpClassName)),
 		uintptr(unsafe.Pointer(lpWindowName)),
@@ -2000,7 +2000,7 @@ func CreateWindowEx(dwExStyle uint32, lpClassName, lpWindowName *uint16, dwStyle
 }
 
 func DeferWindowPos(hWinPosInfo HDWP, hWnd, hWndInsertAfter HWND, x, y, cx, cy int32, uFlags uint32) HDWP {
-	ret, _, _ := syscall.Syscall9(deferWindowPos, 8,
+	ret, _, _ := syscall.Syscall9(deferWindowPos.Addr(), 8,
 		uintptr(hWinPosInfo),
 		uintptr(hWnd),
 		uintptr(hWndInsertAfter),
@@ -2015,7 +2015,7 @@ func DeferWindowPos(hWinPosInfo HDWP, hWnd, hWndInsertAfter HWND, x, y, cx, cy i
 }
 
 func DefWindowProc(hWnd HWND, Msg uint32, wParam, lParam uintptr) uintptr {
-	ret, _, _ := syscall.Syscall6(defWindowProc, 4,
+	ret, _, _ := syscall.Syscall6(defWindowProc.Addr(), 4,
 		uintptr(hWnd),
 		uintptr(Msg),
 		wParam,
@@ -2027,7 +2027,7 @@ func DefWindowProc(hWnd HWND, Msg uint32, wParam, lParam uintptr) uintptr {
 }
 
 func DestroyIcon(hIcon HICON) bool {
-	ret, _, _ := syscall.Syscall(destroyIcon, 1,
+	ret, _, _ := syscall.Syscall(destroyIcon.Addr(), 1,
 		uintptr(hIcon),
 		0,
 		0)
@@ -2036,7 +2036,7 @@ func DestroyIcon(hIcon HICON) bool {
 }
 
 func DestroyMenu(hMenu HMENU) bool {
-	ret, _, _ := syscall.Syscall(destroyMenu, 1,
+	ret, _, _ := syscall.Syscall(destroyMenu.Addr(), 1,
 		uintptr(hMenu),
 		0,
 		0)
@@ -2045,7 +2045,7 @@ func DestroyMenu(hMenu HMENU) bool {
 }
 
 func DestroyWindow(hWnd HWND) bool {
-	ret, _, _ := syscall.Syscall(destroyWindow, 1,
+	ret, _, _ := syscall.Syscall(destroyWindow.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2054,7 +2054,7 @@ func DestroyWindow(hWnd HWND) bool {
 }
 
 func DialogBoxParam(instRes HINSTANCE, name *uint16, parent HWND, proc, param uintptr) int {
-	ret, _, _ := syscall.Syscall6(dialogBoxParam, 5,
+	ret, _, _ := syscall.Syscall6(dialogBoxParam.Addr(), 5,
 		uintptr(instRes),
 		uintptr(unsafe.Pointer(name)),
 		uintptr(parent),
@@ -2066,7 +2066,7 @@ func DialogBoxParam(instRes HINSTANCE, name *uint16, parent HWND, proc, param ui
 }
 
 func DispatchMessage(msg *MSG) uintptr {
-	ret, _, _ := syscall.Syscall(dispatchMessage, 1,
+	ret, _, _ := syscall.Syscall(dispatchMessage.Addr(), 1,
 		uintptr(unsafe.Pointer(msg)),
 		0,
 		0)
@@ -2075,7 +2075,7 @@ func DispatchMessage(msg *MSG) uintptr {
 }
 
 func DrawFocusRect(hDC HDC, lprc *RECT) bool {
-	ret, _, _ := syscall.Syscall(drawFocusRect, 2,
+	ret, _, _ := syscall.Syscall(drawFocusRect.Addr(), 2,
 		uintptr(hDC),
 		uintptr(unsafe.Pointer(lprc)),
 		0)
@@ -2084,7 +2084,7 @@ func DrawFocusRect(hDC HDC, lprc *RECT) bool {
 }
 
 func DrawIconEx(hdc HDC, xLeft, yTop int32, hIcon HICON, cxWidth, cyWidth int32, istepIfAniCur uint32, hbrFlickerFreeDraw HBRUSH, diFlags uint32) bool {
-	ret, _, _ := syscall.Syscall9(drawIconEx, 9,
+	ret, _, _ := syscall.Syscall9(drawIconEx.Addr(), 9,
 		uintptr(hdc),
 		uintptr(xLeft),
 		uintptr(yTop),
@@ -2099,7 +2099,7 @@ func DrawIconEx(hdc HDC, xLeft, yTop int32, hIcon HICON, cxWidth, cyWidth int32,
 }
 
 func DrawMenuBar(hWnd HWND) bool {
-	ret, _, _ := syscall.Syscall(drawMenuBar, 1,
+	ret, _, _ := syscall.Syscall(drawMenuBar.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2108,7 +2108,7 @@ func DrawMenuBar(hWnd HWND) bool {
 }
 
 func DrawTextEx(hdc HDC, lpchText *uint16, cchText int32, lprc *RECT, dwDTFormat uint32, lpDTParams *DRAWTEXTPARAMS) int32 {
-	ret, _, _ := syscall.Syscall6(drawTextEx, 6,
+	ret, _, _ := syscall.Syscall6(drawTextEx.Addr(), 6,
 		uintptr(hdc),
 		uintptr(unsafe.Pointer(lpchText)),
 		uintptr(cchText),
@@ -2120,7 +2120,7 @@ func DrawTextEx(hdc HDC, lpchText *uint16, cchText int32, lprc *RECT, dwDTFormat
 }
 
 func EmptyClipboard() bool {
-	ret, _, _ := syscall.Syscall(emptyClipboard, 0,
+	ret, _, _ := syscall.Syscall(emptyClipboard.Addr(), 0,
 		0,
 		0,
 		0)
@@ -2129,7 +2129,7 @@ func EmptyClipboard() bool {
 }
 
 func EnableWindow(hWnd HWND, bEnable bool) bool {
-	ret, _, _ := syscall.Syscall(enableWindow, 2,
+	ret, _, _ := syscall.Syscall(enableWindow.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(BoolToBOOL(bEnable)),
 		0)
@@ -2138,7 +2138,7 @@ func EnableWindow(hWnd HWND, bEnable bool) bool {
 }
 
 func EndDeferWindowPos(hWinPosInfo HDWP) bool {
-	ret, _, _ := syscall.Syscall(endDeferWindowPos, 1,
+	ret, _, _ := syscall.Syscall(endDeferWindowPos.Addr(), 1,
 		uintptr(hWinPosInfo),
 		0,
 		0)
@@ -2147,7 +2147,7 @@ func EndDeferWindowPos(hWinPosInfo HDWP) bool {
 }
 
 func EndDialog(hwnd HWND, result int) bool {
-	ret, _, _ := syscall.Syscall(endDialog, 2,
+	ret, _, _ := syscall.Syscall(endDialog.Addr(), 2,
 		uintptr(hwnd),
 		uintptr(result),
 		0)
@@ -2156,7 +2156,7 @@ func EndDialog(hwnd HWND, result int) bool {
 }
 
 func EndPaint(hwnd HWND, lpPaint *PAINTSTRUCT) bool {
-	ret, _, _ := syscall.Syscall(endPaint, 2,
+	ret, _, _ := syscall.Syscall(endPaint.Addr(), 2,
 		uintptr(hwnd),
 		uintptr(unsafe.Pointer(lpPaint)),
 		0)
@@ -2165,7 +2165,7 @@ func EndPaint(hwnd HWND, lpPaint *PAINTSTRUCT) bool {
 }
 
 func EnumChildWindows(hWndParent HWND, lpEnumFunc, lParam uintptr) bool {
-	ret, _, _ := syscall.Syscall(enumChildWindows, 3,
+	ret, _, _ := syscall.Syscall(enumChildWindows.Addr(), 3,
 		uintptr(hWndParent),
 		lpEnumFunc,
 		lParam)
@@ -2174,7 +2174,7 @@ func EnumChildWindows(hWndParent HWND, lpEnumFunc, lParam uintptr) bool {
 }
 
 func FindWindow(lpClassName, lpWindowName *uint16) HWND {
-	ret, _, _ := syscall.Syscall(findWindow, 2,
+	ret, _, _ := syscall.Syscall(findWindow.Addr(), 2,
 		uintptr(unsafe.Pointer(lpClassName)),
 		uintptr(unsafe.Pointer(lpWindowName)),
 		0)
@@ -2183,7 +2183,7 @@ func FindWindow(lpClassName, lpWindowName *uint16) HWND {
 }
 
 func GetActiveWindow() HWND {
-	ret, _, _ := syscall.Syscall(getActiveWindow, 0,
+	ret, _, _ := syscall.Syscall(getActiveWindow.Addr(), 0,
 		0,
 		0,
 		0)
@@ -2192,7 +2192,7 @@ func GetActiveWindow() HWND {
 }
 
 func GetAncestor(hWnd HWND, gaFlags uint32) HWND {
-	ret, _, _ := syscall.Syscall(getAncestor, 2,
+	ret, _, _ := syscall.Syscall(getAncestor.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(gaFlags),
 		0)
@@ -2201,7 +2201,7 @@ func GetAncestor(hWnd HWND, gaFlags uint32) HWND {
 }
 
 func GetCaretPos(lpPoint *POINT) bool {
-	ret, _, _ := syscall.Syscall(getCaretPos, 1,
+	ret, _, _ := syscall.Syscall(getCaretPos.Addr(), 1,
 		uintptr(unsafe.Pointer(lpPoint)),
 		0,
 		0)
@@ -2210,7 +2210,7 @@ func GetCaretPos(lpPoint *POINT) bool {
 }
 
 func GetClassName(hWnd HWND, className *uint16, maxCount int) (int, error) {
-	ret, _, e := syscall.Syscall(getClassName, 3,
+	ret, _, e := syscall.Syscall(getClassName.Addr(), 3,
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(className)),
 		uintptr(maxCount))
@@ -2221,7 +2221,7 @@ func GetClassName(hWnd HWND, className *uint16, maxCount int) (int, error) {
 }
 
 func GetClientRect(hWnd HWND, rect *RECT) bool {
-	ret, _, _ := syscall.Syscall(getClientRect, 2,
+	ret, _, _ := syscall.Syscall(getClientRect.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(rect)),
 		0)
@@ -2230,7 +2230,7 @@ func GetClientRect(hWnd HWND, rect *RECT) bool {
 }
 
 func GetClipboardData(uFormat uint32) HANDLE {
-	ret, _, _ := syscall.Syscall(getClipboardData, 1,
+	ret, _, _ := syscall.Syscall(getClipboardData.Addr(), 1,
 		uintptr(uFormat),
 		0,
 		0)
@@ -2239,7 +2239,7 @@ func GetClipboardData(uFormat uint32) HANDLE {
 }
 
 func GetCursorPos(lpPoint *POINT) bool {
-	ret, _, _ := syscall.Syscall(getCursorPos, 1,
+	ret, _, _ := syscall.Syscall(getCursorPos.Addr(), 1,
 		uintptr(unsafe.Pointer(lpPoint)),
 		0,
 		0)
@@ -2248,7 +2248,7 @@ func GetCursorPos(lpPoint *POINT) bool {
 }
 
 func GetDesktopWindow() HWND {
-	ret, _, _ := syscall.Syscall(getDesktopWindow, 0,
+	ret, _, _ := syscall.Syscall(getDesktopWindow.Addr(), 0,
 		0,
 		0,
 		0)
@@ -2257,7 +2257,7 @@ func GetDesktopWindow() HWND {
 }
 
 func GetDC(hWnd HWND) HDC {
-	ret, _, _ := syscall.Syscall(getDC, 1,
+	ret, _, _ := syscall.Syscall(getDC.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2266,7 +2266,7 @@ func GetDC(hWnd HWND) HDC {
 }
 
 func GetFocus() HWND {
-	ret, _, _ := syscall.Syscall(getFocus, 0,
+	ret, _, _ := syscall.Syscall(getFocus.Addr(), 0,
 		0,
 		0,
 		0)
@@ -2275,7 +2275,7 @@ func GetFocus() HWND {
 }
 
 func GetForegroundWindow() HWND {
-	ret, _, _ := syscall.Syscall(getForegroundWindow, 0,
+	ret, _, _ := syscall.Syscall(getForegroundWindow.Addr(), 0,
 		0,
 		0,
 		0)
@@ -2284,7 +2284,7 @@ func GetForegroundWindow() HWND {
 }
 
 func GetKeyState(nVirtKey int32) int16 {
-	ret, _, _ := syscall.Syscall(getKeyState, 1,
+	ret, _, _ := syscall.Syscall(getKeyState.Addr(), 1,
 		uintptr(nVirtKey),
 		0,
 		0)
@@ -2293,7 +2293,7 @@ func GetKeyState(nVirtKey int32) int16 {
 }
 
 func GetMenuInfo(hmenu HMENU, lpcmi *MENUINFO) bool {
-	ret, _, _ := syscall.Syscall(getMenuInfo, 2,
+	ret, _, _ := syscall.Syscall(getMenuInfo.Addr(), 2,
 		uintptr(hmenu),
 		uintptr(unsafe.Pointer(lpcmi)),
 		0)
@@ -2302,7 +2302,7 @@ func GetMenuInfo(hmenu HMENU, lpcmi *MENUINFO) bool {
 }
 
 func GetMessage(msg *MSG, hWnd HWND, msgFilterMin, msgFilterMax uint32) BOOL {
-	ret, _, _ := syscall.Syscall6(getMessage, 4,
+	ret, _, _ := syscall.Syscall6(getMessage.Addr(), 4,
 		uintptr(unsafe.Pointer(msg)),
 		uintptr(hWnd),
 		uintptr(msgFilterMin),
@@ -2314,7 +2314,7 @@ func GetMessage(msg *MSG, hWnd HWND, msgFilterMin, msgFilterMax uint32) BOOL {
 }
 
 func GetMonitorInfo(hMonitor HMONITOR, lpmi *MONITORINFO) bool {
-	ret, _, _ := syscall.Syscall(getMonitorInfo, 2,
+	ret, _, _ := syscall.Syscall(getMonitorInfo.Addr(), 2,
 		uintptr(hMonitor),
 		uintptr(unsafe.Pointer(lpmi)),
 		0)
@@ -2323,7 +2323,7 @@ func GetMonitorInfo(hMonitor HMONITOR, lpmi *MONITORINFO) bool {
 }
 
 func GetParent(hWnd HWND) HWND {
-	ret, _, _ := syscall.Syscall(getParent, 1,
+	ret, _, _ := syscall.Syscall(getParent.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2332,7 +2332,7 @@ func GetParent(hWnd HWND) HWND {
 }
 
 func GetRawInputData(hRawInput HRAWINPUT, uiCommand uint32, pData unsafe.Pointer, pcbSize *uint32, cBSizeHeader uint32) uint32 {
-	ret, _, _ := syscall.Syscall6(getRawInputData, 5,
+	ret, _, _ := syscall.Syscall6(getRawInputData.Addr(), 5,
 		uintptr(hRawInput),
 		uintptr(uiCommand),
 		uintptr(pData),
@@ -2344,7 +2344,7 @@ func GetRawInputData(hRawInput HRAWINPUT, uiCommand uint32, pData unsafe.Pointer
 }
 
 func GetScrollInfo(hwnd HWND, fnBar int32, lpsi *SCROLLINFO) bool {
-	ret, _, _ := syscall.Syscall(getScrollInfo, 3,
+	ret, _, _ := syscall.Syscall(getScrollInfo.Addr(), 3,
 		uintptr(hwnd),
 		uintptr(fnBar),
 		uintptr(unsafe.Pointer(lpsi)))
@@ -2353,7 +2353,7 @@ func GetScrollInfo(hwnd HWND, fnBar int32, lpsi *SCROLLINFO) bool {
 }
 
 func GetSysColor(nIndex int) uint32 {
-	ret, _, _ := syscall.Syscall(getSysColor, 1,
+	ret, _, _ := syscall.Syscall(getSysColor.Addr(), 1,
 		uintptr(nIndex),
 		0,
 		0)
@@ -2362,7 +2362,7 @@ func GetSysColor(nIndex int) uint32 {
 }
 
 func GetSysColorBrush(nIndex int) HBRUSH {
-	ret, _, _ := syscall.Syscall(getSysColorBrush, 1,
+	ret, _, _ := syscall.Syscall(getSysColorBrush.Addr(), 1,
 		uintptr(nIndex),
 		0,
 		0)
@@ -2371,7 +2371,7 @@ func GetSysColorBrush(nIndex int) HBRUSH {
 }
 
 func GetSystemMetrics(nIndex int32) int32 {
-	ret, _, _ := syscall.Syscall(getSystemMetrics, 1,
+	ret, _, _ := syscall.Syscall(getSystemMetrics.Addr(), 1,
 		uintptr(nIndex),
 		0,
 		0)
@@ -2380,7 +2380,7 @@ func GetSystemMetrics(nIndex int32) int32 {
 }
 
 func GetWindow(hWnd HWND, uCmd uint32) HWND {
-	ret, _, _ := syscall.Syscall(getWindow, 2,
+	ret, _, _ := syscall.Syscall(getWindow.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(uCmd),
 		0)
@@ -2389,7 +2389,7 @@ func GetWindow(hWnd HWND, uCmd uint32) HWND {
 }
 
 func GetWindowLong(hWnd HWND, index int32) int32 {
-	ret, _, _ := syscall.Syscall(getWindowLong, 2,
+	ret, _, _ := syscall.Syscall(getWindowLong.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(index),
 		0)
@@ -2398,7 +2398,7 @@ func GetWindowLong(hWnd HWND, index int32) int32 {
 }
 
 func GetWindowLongPtr(hWnd HWND, index int32) uintptr {
-	ret, _, _ := syscall.Syscall(getWindowLongPtr, 2,
+	ret, _, _ := syscall.Syscall(getWindowLongPtr.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(index),
 		0)
@@ -2407,7 +2407,7 @@ func GetWindowLongPtr(hWnd HWND, index int32) uintptr {
 }
 
 func GetWindowPlacement(hWnd HWND, lpwndpl *WINDOWPLACEMENT) bool {
-	ret, _, _ := syscall.Syscall(getWindowPlacement, 2,
+	ret, _, _ := syscall.Syscall(getWindowPlacement.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(lpwndpl)),
 		0)
@@ -2416,7 +2416,7 @@ func GetWindowPlacement(hWnd HWND, lpwndpl *WINDOWPLACEMENT) bool {
 }
 
 func GetWindowRect(hWnd HWND, rect *RECT) bool {
-	ret, _, _ := syscall.Syscall(getWindowRect, 2,
+	ret, _, _ := syscall.Syscall(getWindowRect.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(rect)),
 		0)
@@ -2425,7 +2425,7 @@ func GetWindowRect(hWnd HWND, rect *RECT) bool {
 }
 
 func InsertMenuItem(hMenu HMENU, uItem uint32, fByPosition bool, lpmii *MENUITEMINFO) bool {
-	ret, _, _ := syscall.Syscall6(insertMenuItem, 4,
+	ret, _, _ := syscall.Syscall6(insertMenuItem.Addr(), 4,
 		uintptr(hMenu),
 		uintptr(uItem),
 		uintptr(BoolToBOOL(fByPosition)),
@@ -2437,7 +2437,7 @@ func InsertMenuItem(hMenu HMENU, uItem uint32, fByPosition bool, lpmii *MENUITEM
 }
 
 func InvalidateRect(hWnd HWND, lpRect *RECT, bErase bool) bool {
-	ret, _, _ := syscall.Syscall(invalidateRect, 3,
+	ret, _, _ := syscall.Syscall(invalidateRect.Addr(), 3,
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(lpRect)),
 		uintptr(BoolToBOOL(bErase)))
@@ -2446,7 +2446,7 @@ func InvalidateRect(hWnd HWND, lpRect *RECT, bErase bool) bool {
 }
 
 func IsChild(hWndParent, hWnd HWND) bool {
-	ret, _, _ := syscall.Syscall(isChild, 2,
+	ret, _, _ := syscall.Syscall(isChild.Addr(), 2,
 		uintptr(hWndParent),
 		uintptr(hWnd),
 		0)
@@ -2455,7 +2455,7 @@ func IsChild(hWndParent, hWnd HWND) bool {
 }
 
 func IsClipboardFormatAvailable(format uint32) bool {
-	ret, _, _ := syscall.Syscall(isClipboardFormatAvailable, 1,
+	ret, _, _ := syscall.Syscall(isClipboardFormatAvailable.Addr(), 1,
 		uintptr(format),
 		0,
 		0)
@@ -2464,7 +2464,7 @@ func IsClipboardFormatAvailable(format uint32) bool {
 }
 
 func IsDialogMessage(hWnd HWND, msg *MSG) bool {
-	ret, _, _ := syscall.Syscall(isDialogMessage, 2,
+	ret, _, _ := syscall.Syscall(isDialogMessage.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(msg)),
 		0)
@@ -2473,7 +2473,7 @@ func IsDialogMessage(hWnd HWND, msg *MSG) bool {
 }
 
 func IsWindowEnabled(hWnd HWND) bool {
-	ret, _, _ := syscall.Syscall(isWindowEnabled, 1,
+	ret, _, _ := syscall.Syscall(isWindowEnabled.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2482,7 +2482,7 @@ func IsWindowEnabled(hWnd HWND) bool {
 }
 
 func IsWindowVisible(hWnd HWND) bool {
-	ret, _, _ := syscall.Syscall(isWindowVisible, 1,
+	ret, _, _ := syscall.Syscall(isWindowVisible.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2491,7 +2491,7 @@ func IsWindowVisible(hWnd HWND) bool {
 }
 
 func KillTimer(hWnd HWND, uIDEvent uintptr) bool {
-	ret, _, _ := syscall.Syscall(killTimer, 2,
+	ret, _, _ := syscall.Syscall(killTimer.Addr(), 2,
 		uintptr(hWnd),
 		uIDEvent,
 		0)
@@ -2500,7 +2500,7 @@ func KillTimer(hWnd HWND, uIDEvent uintptr) bool {
 }
 
 func LoadCursor(hInstance HINSTANCE, lpCursorName *uint16) HCURSOR {
-	ret, _, _ := syscall.Syscall(loadCursor, 2,
+	ret, _, _ := syscall.Syscall(loadCursor.Addr(), 2,
 		uintptr(hInstance),
 		uintptr(unsafe.Pointer(lpCursorName)),
 		0)
@@ -2509,7 +2509,7 @@ func LoadCursor(hInstance HINSTANCE, lpCursorName *uint16) HCURSOR {
 }
 
 func LoadIcon(hInstance HINSTANCE, lpIconName *uint16) HICON {
-	ret, _, _ := syscall.Syscall(loadIcon, 2,
+	ret, _, _ := syscall.Syscall(loadIcon.Addr(), 2,
 		uintptr(hInstance),
 		uintptr(unsafe.Pointer(lpIconName)),
 		0)
@@ -2518,7 +2518,7 @@ func LoadIcon(hInstance HINSTANCE, lpIconName *uint16) HICON {
 }
 
 func LoadImage(hinst HINSTANCE, lpszName *uint16, uType uint32, cxDesired, cyDesired int32, fuLoad uint32) HANDLE {
-	ret, _, _ := syscall.Syscall6(loadImage, 6,
+	ret, _, _ := syscall.Syscall6(loadImage.Addr(), 6,
 		uintptr(hinst),
 		uintptr(unsafe.Pointer(lpszName)),
 		uintptr(uType),
@@ -2530,7 +2530,7 @@ func LoadImage(hinst HINSTANCE, lpszName *uint16, uType uint32, cxDesired, cyDes
 }
 
 func LoadMenu(hinst HINSTANCE, name *uint16) HMENU {
-	ret, _, _ := syscall.Syscall(loadMenu, 2,
+	ret, _, _ := syscall.Syscall(loadMenu.Addr(), 2,
 		uintptr(hinst),
 		uintptr(unsafe.Pointer(name)),
 		0)
@@ -2539,7 +2539,7 @@ func LoadMenu(hinst HINSTANCE, name *uint16) HMENU {
 }
 
 func LoadString(instRes HINSTANCE, id uint32, buf *uint16, length int32) int32 {
-	ret, _, _ := syscall.Syscall6(loadString, 4,
+	ret, _, _ := syscall.Syscall6(loadString.Addr(), 4,
 		uintptr(instRes),
 		uintptr(id),
 		uintptr(unsafe.Pointer(buf)),
@@ -2565,7 +2565,7 @@ func LoadString(instRes HINSTANCE, id uint32, buf *uint16, length int32) int32 {
 //
 // The function will return true if the function succeeds, false if otherwise.
 func MessageBeep(uType uint32) bool {
-	ret, _, _ := syscall.Syscall(messageBeep, 2,
+	ret, _, _ := syscall.Syscall(messageBeep.Addr(), 2,
 		uintptr(uType),
 		0,
 		0)
@@ -2574,7 +2574,7 @@ func MessageBeep(uType uint32) bool {
 }
 
 func MessageBox(hWnd HWND, lpText, lpCaption *uint16, uType uint32) int32 {
-	ret, _, _ := syscall.Syscall6(messageBox, 4,
+	ret, _, _ := syscall.Syscall6(messageBox.Addr(), 4,
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(lpText)),
 		uintptr(unsafe.Pointer(lpCaption)),
@@ -2586,7 +2586,7 @@ func MessageBox(hWnd HWND, lpText, lpCaption *uint16, uType uint32) int32 {
 }
 
 func MonitorFromWindow(hwnd HWND, dwFlags uint32) HMONITOR {
-	ret, _, _ := syscall.Syscall(monitorFromWindow, 2,
+	ret, _, _ := syscall.Syscall(monitorFromWindow.Addr(), 2,
 		uintptr(hwnd),
 		uintptr(dwFlags),
 		0)
@@ -2595,7 +2595,7 @@ func MonitorFromWindow(hwnd HWND, dwFlags uint32) HMONITOR {
 }
 
 func MoveWindow(hWnd HWND, x, y, width, height int32, repaint bool) bool {
-	ret, _, _ := syscall.Syscall6(moveWindow, 6,
+	ret, _, _ := syscall.Syscall6(moveWindow.Addr(), 6,
 		uintptr(hWnd),
 		uintptr(x),
 		uintptr(y),
@@ -2607,7 +2607,7 @@ func MoveWindow(hWnd HWND, x, y, width, height int32, repaint bool) bool {
 }
 
 func UnregisterClass(name *uint16) bool {
-	ret, _, _ := syscall.Syscall(unregisterClass, 1,
+	ret, _, _ := syscall.Syscall(unregisterClass.Addr(), 1,
 		uintptr(unsafe.Pointer(name)),
 		0,
 		0)
@@ -2616,7 +2616,7 @@ func UnregisterClass(name *uint16) bool {
 }
 
 func OpenClipboard(hWndNewOwner HWND) bool {
-	ret, _, _ := syscall.Syscall(openClipboard, 1,
+	ret, _, _ := syscall.Syscall(openClipboard.Addr(), 1,
 		uintptr(hWndNewOwner),
 		0,
 		0)
@@ -2625,7 +2625,7 @@ func OpenClipboard(hWndNewOwner HWND) bool {
 }
 
 func PeekMessage(lpMsg *MSG, hWnd HWND, wMsgFilterMin, wMsgFilterMax, wRemoveMsg uint32) bool {
-	ret, _, _ := syscall.Syscall6(peekMessage, 5,
+	ret, _, _ := syscall.Syscall6(peekMessage.Addr(), 5,
 		uintptr(unsafe.Pointer(lpMsg)),
 		uintptr(hWnd),
 		uintptr(wMsgFilterMin),
@@ -2637,7 +2637,7 @@ func PeekMessage(lpMsg *MSG, hWnd HWND, wMsgFilterMin, wMsgFilterMax, wRemoveMsg
 }
 
 func PostMessage(hWnd HWND, msg uint32, wParam, lParam uintptr) uintptr {
-	ret, _, _ := syscall.Syscall6(postMessage, 4,
+	ret, _, _ := syscall.Syscall6(postMessage.Addr(), 4,
 		uintptr(hWnd),
 		uintptr(msg),
 		wParam,
@@ -2649,14 +2649,14 @@ func PostMessage(hWnd HWND, msg uint32, wParam, lParam uintptr) uintptr {
 }
 
 func PostQuitMessage(exitCode int32) {
-	syscall.Syscall(postQuitMessage, 1,
+	syscall.Syscall(postQuitMessage.Addr(), 1,
 		uintptr(exitCode),
 		0,
 		0)
 }
 
 func RegisterClassEx(windowClass *WNDCLASSEX) ATOM {
-	ret, _, _ := syscall.Syscall(registerClassEx, 1,
+	ret, _, _ := syscall.Syscall(registerClassEx.Addr(), 1,
 		uintptr(unsafe.Pointer(windowClass)),
 		0,
 		0)
@@ -2665,7 +2665,7 @@ func RegisterClassEx(windowClass *WNDCLASSEX) ATOM {
 }
 
 func RegisterRawInputDevices(pRawInputDevices *RAWINPUTDEVICE, uiNumDevices uint32, cbSize uint32) bool {
-	ret, _, _ := syscall.Syscall(registerRawInputDevices, 3,
+	ret, _, _ := syscall.Syscall(registerRawInputDevices.Addr(), 3,
 		uintptr(unsafe.Pointer(pRawInputDevices)),
 		uintptr(uiNumDevices),
 		uintptr(cbSize))
@@ -2674,7 +2674,7 @@ func RegisterRawInputDevices(pRawInputDevices *RAWINPUTDEVICE, uiNumDevices uint
 }
 
 func RegisterWindowMessage(lpString *uint16) uint32 {
-	ret, _, _ := syscall.Syscall(registerWindowMessage, 1,
+	ret, _, _ := syscall.Syscall(registerWindowMessage.Addr(), 1,
 		uintptr(unsafe.Pointer(lpString)),
 		0,
 		0)
@@ -2683,7 +2683,7 @@ func RegisterWindowMessage(lpString *uint16) uint32 {
 }
 
 func ReleaseCapture() bool {
-	ret, _, _ := syscall.Syscall(releaseCapture, 0,
+	ret, _, _ := syscall.Syscall(releaseCapture.Addr(), 0,
 		0,
 		0,
 		0)
@@ -2692,7 +2692,7 @@ func ReleaseCapture() bool {
 }
 
 func ReleaseDC(hWnd HWND, hDC HDC) bool {
-	ret, _, _ := syscall.Syscall(releaseDC, 2,
+	ret, _, _ := syscall.Syscall(releaseDC.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(hDC),
 		0)
@@ -2701,7 +2701,7 @@ func ReleaseDC(hWnd HWND, hDC HDC) bool {
 }
 
 func RemoveMenu(hMenu HMENU, uPosition, uFlags uint32) bool {
-	ret, _, _ := syscall.Syscall(removeMenu, 3,
+	ret, _, _ := syscall.Syscall(removeMenu.Addr(), 3,
 		uintptr(hMenu),
 		uintptr(uPosition),
 		uintptr(uFlags))
@@ -2710,7 +2710,7 @@ func RemoveMenu(hMenu HMENU, uPosition, uFlags uint32) bool {
 }
 
 func ScreenToClient(hWnd HWND, point *POINT) bool {
-	ret, _, _ := syscall.Syscall(screenToClient, 2,
+	ret, _, _ := syscall.Syscall(screenToClient.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(point)),
 		0)
@@ -2719,7 +2719,7 @@ func ScreenToClient(hWnd HWND, point *POINT) bool {
 }
 
 func SendDlgItemMessage(hWnd HWND, id int32, msg uint32, wParam, lParam uintptr) uintptr {
-	ret, _, _ := syscall.Syscall6(sendDlgItemMessage, 5,
+	ret, _, _ := syscall.Syscall6(sendDlgItemMessage.Addr(), 5,
 		uintptr(hWnd),
 		uintptr(id),
 		uintptr(msg),
@@ -2732,7 +2732,7 @@ func SendDlgItemMessage(hWnd HWND, id int32, msg uint32, wParam, lParam uintptr)
 
 // pInputs expects a unsafe.Pointer to a slice of MOUSE_INPUT or KEYBD_INPUT or HARDWARE_INPUT structs.
 func SendInput(nInputs uint32, pInputs unsafe.Pointer, cbSize int32) uint32 {
-	ret, _, _ := syscall.Syscall(sendInput, 3,
+	ret, _, _ := syscall.Syscall(sendInput.Addr(), 3,
 		uintptr(nInputs),
 		uintptr(pInputs),
 		uintptr(cbSize))
@@ -2741,7 +2741,7 @@ func SendInput(nInputs uint32, pInputs unsafe.Pointer, cbSize int32) uint32 {
 }
 
 func SendMessage(hWnd HWND, msg uint32, wParam, lParam uintptr) uintptr {
-	ret, _, _ := syscall.Syscall6(sendMessage, 4,
+	ret, _, _ := syscall.Syscall6(sendMessage.Addr(), 4,
 		uintptr(hWnd),
 		uintptr(msg),
 		wParam,
@@ -2753,7 +2753,7 @@ func SendMessage(hWnd HWND, msg uint32, wParam, lParam uintptr) uintptr {
 }
 
 func SetActiveWindow(hWnd HWND) HWND {
-	ret, _, _ := syscall.Syscall(setActiveWindow, 1,
+	ret, _, _ := syscall.Syscall(setActiveWindow.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2762,7 +2762,7 @@ func SetActiveWindow(hWnd HWND) HWND {
 }
 
 func SetCapture(hWnd HWND) HWND {
-	ret, _, _ := syscall.Syscall(setCapture, 1,
+	ret, _, _ := syscall.Syscall(setCapture.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2771,7 +2771,7 @@ func SetCapture(hWnd HWND) HWND {
 }
 
 func SetClipboardData(uFormat uint32, hMem HANDLE) HANDLE {
-	ret, _, _ := syscall.Syscall(setClipboardData, 2,
+	ret, _, _ := syscall.Syscall(setClipboardData.Addr(), 2,
 		uintptr(uFormat),
 		uintptr(hMem),
 		0)
@@ -2780,7 +2780,7 @@ func SetClipboardData(uFormat uint32, hMem HANDLE) HANDLE {
 }
 
 func SetCursor(hCursor HCURSOR) HCURSOR {
-	ret, _, _ := syscall.Syscall(setCursor, 1,
+	ret, _, _ := syscall.Syscall(setCursor.Addr(), 1,
 		uintptr(hCursor),
 		0,
 		0)
@@ -2789,7 +2789,7 @@ func SetCursor(hCursor HCURSOR) HCURSOR {
 }
 
 func SetCursorPos(X, Y int32) bool {
-	ret, _, _ := syscall.Syscall(setCursorPos, 2,
+	ret, _, _ := syscall.Syscall(setCursorPos.Addr(), 2,
 		uintptr(X),
 		uintptr(Y),
 		0)
@@ -2798,7 +2798,7 @@ func SetCursorPos(X, Y int32) bool {
 }
 
 func SetFocus(hWnd HWND) HWND {
-	ret, _, _ := syscall.Syscall(setFocus, 1,
+	ret, _, _ := syscall.Syscall(setFocus.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2807,7 +2807,7 @@ func SetFocus(hWnd HWND) HWND {
 }
 
 func SetForegroundWindow(hWnd HWND) bool {
-	ret, _, _ := syscall.Syscall(setForegroundWindow, 1,
+	ret, _, _ := syscall.Syscall(setForegroundWindow.Addr(), 1,
 		uintptr(hWnd),
 		0,
 		0)
@@ -2816,7 +2816,7 @@ func SetForegroundWindow(hWnd HWND) bool {
 }
 
 func SetMenu(hWnd HWND, hMenu HMENU) bool {
-	ret, _, _ := syscall.Syscall(setMenu, 2,
+	ret, _, _ := syscall.Syscall(setMenu.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(hMenu),
 		0)
@@ -2825,7 +2825,7 @@ func SetMenu(hWnd HWND, hMenu HMENU) bool {
 }
 
 func SetMenuInfo(hmenu HMENU, lpcmi *MENUINFO) bool {
-	ret, _, _ := syscall.Syscall(setMenuInfo, 2,
+	ret, _, _ := syscall.Syscall(setMenuInfo.Addr(), 2,
 		uintptr(hmenu),
 		uintptr(unsafe.Pointer(lpcmi)),
 		0)
@@ -2834,7 +2834,7 @@ func SetMenuInfo(hmenu HMENU, lpcmi *MENUINFO) bool {
 }
 
 func SetMenuItemInfo(hMenu HMENU, uItem uint32, fByPosition bool, lpmii *MENUITEMINFO) bool {
-	ret, _, _ := syscall.Syscall6(setMenuItemInfo, 4,
+	ret, _, _ := syscall.Syscall6(setMenuItemInfo.Addr(), 4,
 		uintptr(hMenu),
 		uintptr(uItem),
 		uintptr(BoolToBOOL(fByPosition)),
@@ -2846,7 +2846,7 @@ func SetMenuItemInfo(hMenu HMENU, uItem uint32, fByPosition bool, lpmii *MENUITE
 }
 
 func SetParent(hWnd HWND, parentHWnd HWND) HWND {
-	ret, _, _ := syscall.Syscall(setParent, 2,
+	ret, _, _ := syscall.Syscall(setParent.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(parentHWnd),
 		0)
@@ -2855,7 +2855,7 @@ func SetParent(hWnd HWND, parentHWnd HWND) HWND {
 }
 
 func SetRect(lprc *RECT, xLeft, yTop, xRight, yBottom uint32) BOOL {
-	ret, _, _ := syscall.Syscall6(setRect, 5,
+	ret, _, _ := syscall.Syscall6(setRect.Addr(), 5,
 		uintptr(unsafe.Pointer(lprc)),
 		uintptr(xLeft),
 		uintptr(yTop),
@@ -2867,7 +2867,7 @@ func SetRect(lprc *RECT, xLeft, yTop, xRight, yBottom uint32) BOOL {
 }
 
 func SetScrollInfo(hwnd HWND, fnBar int32, lpsi *SCROLLINFO, fRedraw bool) int32 {
-	ret, _, _ := syscall.Syscall6(setScrollInfo, 4,
+	ret, _, _ := syscall.Syscall6(setScrollInfo.Addr(), 4,
 		uintptr(hwnd),
 		uintptr(fnBar),
 		uintptr(unsafe.Pointer(lpsi)),
@@ -2879,7 +2879,7 @@ func SetScrollInfo(hwnd HWND, fnBar int32, lpsi *SCROLLINFO, fRedraw bool) int32
 }
 
 func SetTimer(hWnd HWND, nIDEvent uintptr, uElapse uint32, lpTimerFunc uintptr) uintptr {
-	ret, _, _ := syscall.Syscall6(setTimer, 4,
+	ret, _, _ := syscall.Syscall6(setTimer.Addr(), 4,
 		uintptr(hWnd),
 		nIDEvent,
 		uintptr(uElapse),
@@ -2893,7 +2893,7 @@ func SetTimer(hWnd HWND, nIDEvent uintptr, uElapse uint32, lpTimerFunc uintptr) 
 type WINEVENTPROC func(hWinEventHook HWINEVENTHOOK, event uint32, hwnd HWND, idObject int32, idChild int32, idEventThread uint32, dwmsEventTime uint32) uintptr
 
 func SetWinEventHook(eventMin uint32, eventMax uint32, hmodWinEventProc HMODULE, callbackFunction WINEVENTPROC, idProcess uint32, idThread uint32, dwFlags uint32) (HWINEVENTHOOK, error) {
-	ret, _, err := syscall.Syscall9(setWinEventHook, 7,
+	ret, _, err := syscall.Syscall9(setWinEventHook.Addr(), 7,
 		uintptr(eventMin),
 		uintptr(eventMax),
 		uintptr(hmodWinEventProc),
@@ -2911,7 +2911,7 @@ func SetWinEventHook(eventMin uint32, eventMax uint32, hmodWinEventProc HMODULE,
 }
 
 func SetWindowLong(hWnd HWND, index, value int32) int32 {
-	ret, _, _ := syscall.Syscall(setWindowLong, 3,
+	ret, _, _ := syscall.Syscall(setWindowLong.Addr(), 3,
 		uintptr(hWnd),
 		uintptr(index),
 		uintptr(value))
@@ -2920,7 +2920,7 @@ func SetWindowLong(hWnd HWND, index, value int32) int32 {
 }
 
 func SetWindowLongPtr(hWnd HWND, index int, value uintptr) uintptr {
-	ret, _, _ := syscall.Syscall(setWindowLongPtr, 3,
+	ret, _, _ := syscall.Syscall(setWindowLongPtr.Addr(), 3,
 		uintptr(hWnd),
 		uintptr(index),
 		value)
@@ -2929,7 +2929,7 @@ func SetWindowLongPtr(hWnd HWND, index int, value uintptr) uintptr {
 }
 
 func SetWindowPlacement(hWnd HWND, lpwndpl *WINDOWPLACEMENT) bool {
-	ret, _, _ := syscall.Syscall(setWindowPlacement, 2,
+	ret, _, _ := syscall.Syscall(setWindowPlacement.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(unsafe.Pointer(lpwndpl)),
 		0)
@@ -2938,7 +2938,7 @@ func SetWindowPlacement(hWnd HWND, lpwndpl *WINDOWPLACEMENT) bool {
 }
 
 func SetWindowPos(hWnd, hWndInsertAfter HWND, x, y, width, height int32, flags uint32) bool {
-	ret, _, _ := syscall.Syscall9(setWindowPos, 7,
+	ret, _, _ := syscall.Syscall9(setWindowPos.Addr(), 7,
 		uintptr(hWnd),
 		uintptr(hWndInsertAfter),
 		uintptr(x),
@@ -2953,7 +2953,7 @@ func SetWindowPos(hWnd, hWndInsertAfter HWND, x, y, width, height int32, flags u
 }
 
 func ShowWindow(hWnd HWND, nCmdShow int32) bool {
-	ret, _, _ := syscall.Syscall(showWindow, 2,
+	ret, _, _ := syscall.Syscall(showWindow.Addr(), 2,
 		uintptr(hWnd),
 		uintptr(nCmdShow),
 		0)
@@ -2962,7 +2962,7 @@ func ShowWindow(hWnd HWND, nCmdShow int32) bool {
 }
 
 func SystemParametersInfo(uiAction, uiParam uint32, pvParam unsafe.Pointer, fWinIni uint32) bool {
-	ret, _, _ := syscall.Syscall6(systemParametersInfo, 4,
+	ret, _, _ := syscall.Syscall6(systemParametersInfo.Addr(), 4,
 		uintptr(uiAction),
 		uintptr(uiParam),
 		uintptr(pvParam),
@@ -2974,7 +2974,7 @@ func SystemParametersInfo(uiAction, uiParam uint32, pvParam unsafe.Pointer, fWin
 }
 
 func TrackPopupMenuEx(hMenu HMENU, fuFlags uint32, x, y int32, hWnd HWND, lptpm *TPMPARAMS) BOOL {
-	ret, _, _ := syscall.Syscall6(trackPopupMenuEx, 6,
+	ret, _, _ := syscall.Syscall6(trackPopupMenuEx.Addr(), 6,
 		uintptr(hMenu),
 		uintptr(fuFlags),
 		uintptr(x),
@@ -2986,7 +2986,7 @@ func TrackPopupMenuEx(hMenu HMENU, fuFlags uint32, x, y int32, hWnd HWND, lptpm 
 }
 
 func TranslateMessage(msg *MSG) bool {
-	ret, _, _ := syscall.Syscall(translateMessage, 1,
+	ret, _, _ := syscall.Syscall(translateMessage.Addr(), 1,
 		uintptr(unsafe.Pointer(msg)),
 		0,
 		0)
@@ -2995,12 +2995,12 @@ func TranslateMessage(msg *MSG) bool {
 }
 
 func UnhookWinEvent(hWinHookEvent HWINEVENTHOOK) bool {
-	ret, _, _ := syscall.Syscall(unhookWinEvent, 1, uintptr(hWinHookEvent), 0, 0)
+	ret, _, _ := syscall.Syscall(unhookWinEvent.Addr(), 1, uintptr(hWinHookEvent), 0, 0)
 	return ret != 0
 }
 
 func UpdateWindow(hwnd HWND) bool {
-	ret, _, _ := syscall.Syscall(updateWindow, 1,
+	ret, _, _ := syscall.Syscall(updateWindow.Addr(), 1,
 		uintptr(hwnd),
 		0,
 		0)
@@ -3009,7 +3009,7 @@ func UpdateWindow(hwnd HWND) bool {
 }
 
 func WindowFromDC(hDC HDC) HWND {
-	ret, _, _ := syscall.Syscall(windowFromDC, 1,
+	ret, _, _ := syscall.Syscall(windowFromDC.Addr(), 1,
 		uintptr(hDC),
 		0,
 		0)
@@ -3018,7 +3018,7 @@ func WindowFromDC(hDC HDC) HWND {
 }
 
 func WindowFromPoint(Point POINT) HWND {
-	ret, _, _ := syscall.Syscall(windowFromPoint, 2,
+	ret, _, _ := syscall.Syscall(windowFromPoint.Addr(), 2,
 		uintptr(Point.X),
 		uintptr(Point.Y),
 		0)

--- a/win.go
+++ b/win.go
@@ -42,30 +42,6 @@ type (
 	HRESULT int32
 )
 
-func MustLoadLibrary(name string) uintptr {
-	lib, err := syscall.LoadLibrary(name)
-	if err != nil {
-		panic(err)
-	}
-
-	return uintptr(lib)
-}
-
-func MustGetProcAddress(lib uintptr, name string) uintptr {
-	addr, err := syscall.GetProcAddress(syscall.Handle(lib), name)
-	if err != nil {
-		panic(err)
-	}
-
-	return uintptr(addr)
-}
-
-func MaybeGetProcAddress(lib uintptr, name string) uintptr {
-	addr, _ := syscall.GetProcAddress(syscall.Handle(lib), name)
-
-	return uintptr(addr)
-}
-
 func SUCCEEDED(hr HRESULT) bool {
 	return hr >= 0
 }


### PR DESCRIPTION
**This PR is security-related.**

Prior this was vulnerable to DLL injection attacks. While the syscall
package whitelists a few DLLs for safe loading, it doesn't whitelist all
of the ones we need. Hence our only solution is x/sys/windows, which can
do this right. On the plus side, however, we get to do this lazily,
which means we're not loading tons of useless DLLs in polyglot apps that
have win linked in but don't use it all or in all modes of the app.