### PR TITLE
kernel32: GetVersion returns a DWORD

### DIFF
--- a/kernel32.go
+++ b/kernel32.go
@@ -318,12 +318,12 @@ func GetThreadUILanguage() LANGID {
 	return LANGID(ret)
 }
 
-func GetVersion() int64 {
+func GetVersion() uint32 {
 	ret, _, _ := syscall.Syscall(getVersion.Addr(), 0,
 		0,
 		0,
 		0)
-	return int64(ret)
+	return uint32(ret)
 }
 
 func GlobalAlloc(uFlags uint32, dwBytes uintptr) HGLOBAL {


### PR DESCRIPTION
The docs say: https://docs.microsoft.com/en-us/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversion

Was there a reason this was a signed int64, or was that mostly a mistake?