### PR TITLE
Leave it up to the app to lock thread

### DIFF
--- a/win.go
+++ b/win.go
@@ -7,14 +7,9 @@
 package win
 
 import (
-	"runtime"
 	"syscall"
 	"unsafe"
 )
-
-func init() {
-	runtime.LockOSThread()
-}
 
 const (
 	S_OK           = 0x00000000


### PR DESCRIPTION
There's no good reason to impose this on everybody who imports the win library for a single task.

See https://github.com/lxn/walk/pull/516