### PR TITLE
Add new functions RegisterHotKey/UnregisterHotKey/GetCurrentProcessId 

### DIFF
--- a/kernel32.go
+++ b/kernel32.go
@@ -64,6 +64,8 @@ var (
 	fileTimeToSystemTime               *windows.LazyProc
 	getConsoleTitle                    *windows.LazyProc
 	getConsoleWindow                   *windows.LazyProc
+	getCurrentProcessId                *windows.LazyProc
+	getCurrentThreadId                 *windows.LazyProc
 	getLastError                       *windows.LazyProc
 	getLocaleInfo                      *windows.LazyProc
 	getLogicalDriveStrings             *windows.LazyProc
@@ -144,6 +146,8 @@ func init() {
 	fileTimeToSystemTime = libkernel32.NewProc("FileTimeToSystemTime")
 	getConsoleTitle = libkernel32.NewProc("GetConsoleTitleW")
 	getConsoleWindow = libkernel32.NewProc("GetConsoleWindow")
+	getCurrentProcessId = libkernel32.NewProc("GetCurrentProcessId")
+	getCurrentThreadId = libkernel32.NewProc("GetCurrentThreadId")
 	getLastError = libkernel32.NewProc("GetLastError")
 	getLocaleInfo = libkernel32.NewProc("GetLocaleInfoW")
 	getLogicalDriveStrings = libkernel32.NewProc("GetLogicalDriveStringsW")
@@ -220,6 +224,24 @@ func GetConsoleWindow() HWND {
 		0)
 
 	return HWND(ret)
+}
+
+func GetCurrentProcessId() uint32 {
+	ret, _, _ := syscall.Syscall(getCurrentProcessId.Addr(), 0,
+		0,
+		0,
+		0)
+
+	return uint32(ret)
+}
+
+func GetCurrentThreadId() uint32 {
+	ret, _, _ := syscall.Syscall(getCurrentThreadId.Addr(), 0,
+		0,
+		0,
+		0)
+
+	return uint32(ret)
 }
 
 func GetLastError() uint32 {

--- a/user32.go
+++ b/user32.go
@@ -1677,6 +1677,7 @@ var (
 	postMessage                *windows.LazyProc
 	postQuitMessage            *windows.LazyProc
 	registerClassEx            *windows.LazyProc
+	registerHotKey             *windows.LazyProc
 	registerRawInputDevices    *windows.LazyProc
 	registerWindowMessage      *windows.LazyProc
 	releaseCapture             *windows.LazyProc
@@ -1710,6 +1711,7 @@ var (
 	trackPopupMenuEx           *windows.LazyProc
 	translateMessage           *windows.LazyProc
 	unhookWinEvent             *windows.LazyProc
+	unregisterHotKey           *windows.LazyProc
 	updateWindow               *windows.LazyProc
 	windowFromDC               *windows.LazyProc
 	windowFromPoint            *windows.LazyProc
@@ -1809,6 +1811,7 @@ func init() {
 	postMessage = libuser32.NewProc("PostMessageW")
 	postQuitMessage = libuser32.NewProc("PostQuitMessage")
 	registerClassEx = libuser32.NewProc("RegisterClassExW")
+	registerHotKey = libuser32.NewProc("RegisterHotKey")
 	registerRawInputDevices = libuser32.NewProc("RegisterRawInputDevices")
 	registerWindowMessage = libuser32.NewProc("RegisterWindowMessageW")
 	releaseCapture = libuser32.NewProc("ReleaseCapture")
@@ -1847,6 +1850,7 @@ func init() {
 	trackPopupMenuEx = libuser32.NewProc("TrackPopupMenuEx")
 	translateMessage = libuser32.NewProc("TranslateMessage")
 	unhookWinEvent = libuser32.NewProc("UnhookWinEvent")
+	unregisterHotKey = libuser32.NewProc("UnregisterHotKey")
 	updateWindow = libuser32.NewProc("UpdateWindow")
 	windowFromDC = libuser32.NewProc("WindowFromDC")
 	windowFromPoint = libuser32.NewProc("WindowFromPoint")
@@ -2674,6 +2678,18 @@ func RegisterClassEx(windowClass *WNDCLASSEX) ATOM {
 	return ATOM(ret)
 }
 
+func RegisterHotKey(hwnd HWND, id int, fsModifiers, vk uint) bool {
+	ret, _, _ := syscall.Syscall6(registerHotKey.Addr(), 4,
+		uintptr(hwnd),
+		uintptr(id),
+		uintptr(fsModifiers),
+		uintptr(vk),
+		0,
+		0)
+
+	return ret != 0
+}
+
 func RegisterRawInputDevices(pRawInputDevices *RAWINPUTDEVICE, uiNumDevices uint32, cbSize uint32) bool {
 	ret, _, _ := syscall.Syscall(registerRawInputDevices.Addr(), 3,
 		uintptr(unsafe.Pointer(pRawInputDevices)),
@@ -3006,6 +3022,15 @@ func TranslateMessage(msg *MSG) bool {
 
 func UnhookWinEvent(hWinHookEvent HWINEVENTHOOK) bool {
 	ret, _, _ := syscall.Syscall(unhookWinEvent.Addr(), 1, uintptr(hWinHookEvent), 0, 0)
+	return ret != 0
+}
+
+func UnregisterHotKey(hwnd HWND, id int) bool {
+	ret, _, _ := syscall.Syscall(unregisterHotKey.Addr(), 2,
+		uintptr(hwnd),
+		uintptr(id),
+		0)
+
 	return ret != 0
 }
 

--- a/user32.go
+++ b/user32.go
@@ -468,6 +468,14 @@ const (
 	UISF_ACTIVE    = 0x4
 )
 
+// Key Modifiers
+const (
+	MOD_ALT     = 0x0001
+	MOD_CONTROL = 0x0002
+	MOD_SHIFT   = 0x0004
+	MOD_WIN     = 0x0008
+)
+
 // Virtual key codes
 const (
 	VK_LBUTTON             = 1
@@ -1598,6 +1606,7 @@ var (
 	addClipboardFormatListener *windows.LazyProc
 	adjustWindowRect           *windows.LazyProc
 	animateWindow              *windows.LazyProc
+	attachThreadInput          *windows.LazyProc
 	beginDeferWindowPos        *windows.LazyProc
 	beginPaint                 *windows.LazyProc
 	bringWindowToTop           *windows.LazyProc
@@ -1654,6 +1663,7 @@ var (
 	getWindowLongPtr           *windows.LazyProc
 	getWindowPlacement         *windows.LazyProc
 	getWindowRect              *windows.LazyProc
+	getWindowThreadProcessId   *windows.LazyProc
 	insertMenuItem             *windows.LazyProc
 	invalidateRect             *windows.LazyProc
 	isChild                    *windows.LazyProc
@@ -1727,6 +1737,7 @@ func init() {
 	addClipboardFormatListener = libuser32.NewProc("AddClipboardFormatListener")
 	adjustWindowRect = libuser32.NewProc("AdjustWindowRect")
 	animateWindow = libuser32.NewProc("AnimateWindow")
+	attachThreadInput = libuser32.NewProc("AttachThreadInput")
 	beginDeferWindowPos = libuser32.NewProc("BeginDeferWindowPos")
 	beginPaint = libuser32.NewProc("BeginPaint")
 	bringWindowToTop = libuser32.NewProc("BringWindowToTop")
@@ -1788,6 +1799,7 @@ func init() {
 	}
 	getWindowPlacement = libuser32.NewProc("GetWindowPlacement")
 	getWindowRect = libuser32.NewProc("GetWindowRect")
+	getWindowThreadProcessId = libuser32.NewProc("GetWindowThreadProcessId")
 	insertMenuItem = libuser32.NewProc("InsertMenuItemW")
 	invalidateRect = libuser32.NewProc("InvalidateRect")
 	isChild = libuser32.NewProc("IsChild")
@@ -1883,6 +1895,15 @@ func AnimateWindow(hwnd HWND, dwTime, dwFlags uint32) bool {
 		uintptr(hwnd),
 		uintptr(dwTime),
 		uintptr(dwFlags))
+
+	return ret != 0
+}
+
+func AttachThreadInput(idAttach uint32, idAttachTo uint32, fAttach bool) bool {
+	ret, _, _ := syscall.Syscall(attachThreadInput.Addr(), 3,
+		uintptr(idAttach),
+		uintptr(idAttachTo),
+		uintptr(BoolToBOOL(fAttach)))
 
 	return ret != 0
 }
@@ -2436,6 +2457,15 @@ func GetWindowRect(hWnd HWND, rect *RECT) bool {
 		0)
 
 	return ret != 0
+}
+
+func GetWindowThreadProcessId(hWnd HWND, lpdwProcessId uint32) uint32 {
+	ret, _, _ := syscall.Syscall(getWindowThreadProcessId.Addr(), 2,
+		uintptr(hWnd),
+		uintptr(lpdwProcessId),
+		0)
+
+	return uint32(ret)
 }
 
 func InsertMenuItem(hMenu HMENU, uItem uint32, fByPosition bool, lpmii *MENUITEMINFO) bool {


### PR DESCRIPTION
Add RegisterHotKey and UnregisterHotKey functions in user32

Add GetCurrentProcessId in kernel32

AttachThreadInput and GetWindowThreadProcessId were added as well earlier, but conflicted with another merge at the same time. Re-organized so they were in order.