### PR TITLE
user32: do more faithful emulation of GetSystemMetricsForDpi for Win<10 on HiDPI

### DIFF
--- a/user32.go
+++ b/user32.go
@@ -7,6 +7,7 @@
 package win
 
 import (
+	"math"
 	"syscall"
 	"unsafe"
 
@@ -2648,7 +2649,7 @@ func GetSystemMetrics(nIndex int32) int32 {
 
 func GetSystemMetricsForDpi(nIndex int32, dpi uint32) int32 {
 	if getSystemMetricsForDpi.Find() != nil {
-		return GetSystemMetrics(nIndex)
+		return int32(math.Round(float64(GetSystemMetrics(nIndex)) * float64(dpi) / float64(GetDpiForWindow(0))))
 	}
 
 	ret, _, _ := syscall.Syscall(getSystemMetricsForDpi.Addr(), 2,


### PR DESCRIPTION
This is a replacement for https://github.com/lxn/walk/pull/641