### PR TITLE
Fix Go 1.15 checkptr failure; use golang.org/x/sys/windows.UTF16PtrToString

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,11 +13,14 @@ Alexander Neumann <an2048@googlemail.com>
 Aman Gupta <aman@tmm1.net>
 Anton Lahti <antonlahti@gmail.com>
 Benny Siegert <bsiegert@gmail.com>
+Brad Fitzpatrick <bradfitz@tailscale.com>
 Bruno Bigras <bigras.bruno@gmail.com>
 Carl Kittelberger <icedream@icedream.pw>
 Carlos Cobo <toqueteos@gmail.com>
 Cary Cherng <ccherng@gmail.com>
+Cory Redmond <ace@ac3-servers.eu>
 David Porter <david@porter.me>
+Dmitry Bagdanov <dimbojob@gmail.com>
 gonutz
 Hill <zhubicen@gmail.com>
 Jason A. Donenfeld <Jason@zx2c4.com>
@@ -29,6 +32,3 @@ ryujimiya <ryujimiya236@gmail.com>
 Simon Rozman <simon@rozman.si>
 Tiago Carvalho <sugoiuguu@tfwno.gf>
 wsf01 <wf1337@sina.com>
-gonutz
-Cory Redmond <ace@ac3-servers.eu>
-Dmitry Bagdanov <dimbojob@gmail.com>

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/lxn/win
 
 go 1.12
 
-require golang.org/x/sys v0.0.0-20190904154756-749cb33beabd
+require golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13

--- a/win.go
+++ b/win.go
@@ -7,8 +7,9 @@
 package win
 
 import (
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -70,10 +71,7 @@ func HIWORD(dw uint32) uint16 {
 }
 
 func UTF16PtrToString(s *uint16) string {
-	if s == nil {
-		return ""
-	}
-	return syscall.UTF16ToString((*[1 << 29]uint16)(unsafe.Pointer(s))[0:])
+	return windows.UTF16PtrToString(s)
 }
 
 func MAKEINTRESOURCE(id uintptr) *uint16 {


### PR DESCRIPTION
The UTF16PtrToString version in golang.org/x/sys/windows doesn't
make slices pointing past the end of an allocation. Use it instead.

This lets programs using lxn/win and built with Go's race detector get
a bit further. Other race/checkptr issues with lxn/win and lxn/walk
remain for subsequent changes.

Signed-off-by: Brad Fitzpatrick <brad@danga.com>