### PR TITLE
Add PDH counter wildcard and localization support

### DIFF
--- a/pdh.go
+++ b/pdh.go
@@ -125,28 +125,28 @@ type (
 
 // For struct details, see https://learn.microsoft.com/en-us/windows/win32/api/pdh/ns-pdh-pdh_counter_info_w.
 type PDH_COUNTER_INFO struct {
-	dwLength        uint32
-	dwType          uint32
+	DwLength        uint32
+	DwType          uint32
 	CVersion        uint32
 	CStatus         uint32
-	lScale          int32
-	lDefaultScale   int32
-	dwUserData      *uint32
-	dwQueryUserData *uint32
-	szFullPath      *uint16 // pointer to a string
-	CounterPath     *PDH_COUNTER_PATH_ELEMENTS
-	szExplainText   *uint16 // pointer to a string
+	LScale          int32
+	LDefaultScale   int32
+	DwUserData      *uint32
+	DwQueryUserData *uint32
+	SzFullPath      *uint16 // pointer to a string
+	CounterPath     PDH_COUNTER_PATH_ELEMENTS
+	SzExplainText   *uint16 // pointer to a string
 	DataBuffer      *string
 }
 
 // For struct details, see https://learn.microsoft.com/en-us/windows/win32/api/pdh/ns-pdh-pdh_counter_path_elements_w.
 type PDH_COUNTER_PATH_ELEMENTS struct {
-	szMachineName    *uint16 // pointer to a string
-	szObjectName     *uint16 // pointer to a string
-	szInstanceName   *uint16 // pointer to a string
-	szParentInstance *uint16 // pointer to a string
-	dwInstanceIndex  *uint32
-	szCounterName    *uint16 // pointer to a string
+	SzMachineName    *uint16 // pointer to a string
+	SzObjectName     *uint16 // pointer to a string
+	SzInstanceName   *uint16 // pointer to a string
+	SzParentInstance *uint16 // pointer to a string
+	DwInstanceIndex  *uint32
+	SzCounterName    *uint16 // pointer to a string
 }
 
 // Union specialization for double values
@@ -195,6 +195,7 @@ var (
 	pdh_AddEnglishCounterW        *windows.LazyProc
 	pdh_CloseQuery                *windows.LazyProc
 	pdh_CollectQueryData          *windows.LazyProc
+	pdh_ExpandWildCardPath        *windows.LazyProc
 	pdh_GetCounterInfo            *windows.LazyProc
 	pdh_GetFormattedCounterValue  *windows.LazyProc
 	pdh_GetFormattedCounterArrayW *windows.LazyProc
@@ -211,6 +212,7 @@ func init() {
 	pdh_AddEnglishCounterW = libpdhDll.NewProc("PdhAddEnglishCounterW")
 	pdh_CloseQuery = libpdhDll.NewProc("PdhCloseQuery")
 	pdh_CollectQueryData = libpdhDll.NewProc("PdhCollectQueryData")
+	pdh_ExpandWildCardPath = libpdhDll.NewProc("PdhExpandWildCardPathW")
 	pdh_GetCounterInfo = libpdhDll.NewProc("PdhGetCounterInfoW")
 	pdh_GetFormattedCounterValue = libpdhDll.NewProc("PdhGetFormattedCounterValue")
 	pdh_GetFormattedCounterArrayW = libpdhDll.NewProc("PdhGetFormattedCounterArrayW")
@@ -315,6 +317,19 @@ func PdhCloseQuery(hQuery PDH_HQUERY) uint32 {
 // displaying the correct data for the processor idle time. The second call will have a 0 return code.
 func PdhCollectQueryData(hQuery PDH_HQUERY) uint32 {
 	ret, _, _ := pdh_CollectQueryData.Call(uintptr(hQuery))
+
+	return uint32(ret)
+}
+
+// Examines the specified computer or log file and returns those counter paths that match the given counter path which contains wildcard characters.
+// For more information, see https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhexpandwildcardpathw.
+func PdhExpandWildCardPath(szDataSource *uint16, szWildCardPath *uint16, mszExpandedPathList *uint16, pcchPathListLength *uint32, dwFlags *uint32) uint32 {
+	ret, _, _ := pdh_ExpandWildCardPath.Call(
+		uintptr(unsafe.Pointer(szDataSource)),
+		uintptr(unsafe.Pointer(szWildCardPath)),
+		uintptr(unsafe.Pointer(mszExpandedPathList)),
+		uintptr(unsafe.Pointer(pcchPathListLength)),
+		uintptr(unsafe.Pointer(dwFlags)))
 
 	return uint32(ret)
 }


### PR DESCRIPTION
# Problem

Microsoft specifies the following method for expanding wildcards and using language-neutral counters (from https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcounterw#remarks):

> 1. Make a query
> 2. Use [PdhAddEnglishCounter](https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhaddenglishcounterw) with the string containing wildcards
> 3. Use [PdhGetCounterInfo](https://learn.microsoft.com/en-us/windows/desktop/api/pdh/nf-pdh-pdhgetcounterinfow) on the counter handle returned by PdhAddEnglishCounter to get a localized full path (szFullPath.) This string still contains wildcards, but the non-wildcard parts are now localized.
> 4. Use [PdhExpandWildCardPath](https://learn.microsoft.com/en-us/windows/desktop/api/pdh/nf-pdh-pdhexpandwildcardpathw) to expand the wildcards.
> 5. Use [PdhAddCounter](https://learn.microsoft.com/en-us/windows/desktop/api/pdh/nf-pdh-pdhaddcounterw) on each of the resulting paths


# Solution

The [PdhAddCounter](https://github.com/lxn/win/blob/master/pdh.go#L231) and [PdhAddEnglishCounter](https://github.com/lxn/win/blob/master/pdh.go#L242) functions already exist. This PR adds the missing [PdhGetCounterInfo](https://learn.microsoft.com/en-us/windows/desktop/api/pdh/nf-pdh-pdhgetcounterinfoa) and [PdhExpandWildCardPath](https://learn.microsoft.com/en-us/windows/desktop/api/pdh/nf-pdh-pdhexpandwildcardpatha) functions needed to localize counter names.

These functions allow me to expand `\physicaldisk(*)\avg. disk bytes/read` to:
- `\\MYMACHINE\PhysicalDisk(0 C: F:)\Avg. Disk Bytes/Read`
- `\\MYMACHINE\PhysicalDisk(1)\Avg. Disk Bytes/Read`
- `\\MYMACHINE\PhysicalDisk(_Total)\Avg. Disk Bytes/Read`