### PR TITLE
fix(pdh): align PDH double and large counter values on windows/386

### DIFF
--- a/pdh.go
+++ b/pdh.go
@@ -126,12 +126,14 @@ type (
 // Union specialization for double values
 type PDH_FMT_COUNTERVALUE_DOUBLE struct {
 	CStatus     uint32
+	_           uint32
 	DoubleValue float64
 }
 
 // Union specialization for 64 bit integer values
 type PDH_FMT_COUNTERVALUE_LARGE struct {
 	CStatus    uint32
+	_          uint32
 	LargeValue int64
 }
 


### PR DESCRIPTION
This PR fixes the layout of PDH formatted counter value specializations on 32-bit Windows.

Background
PDH_FMT_COUNTERVALUE is a native Windows structure containing a DWORD CStatus
followed by a union. In the current Go specialization, the 8-byte value fields
were defined immediately after CStatus, for example:

    type PDH_FMT_COUNTERVALUE_DOUBLE struct {
        CStatus     uint32
        DoubleValue float64
    }

and

    type PDH_FMT_COUNTERVALUE_LARGE struct {
        CStatus    uint32
        LargeValue int64
    }

On windows/386 this can lead to a layout mismatch with the native PDH structure,
because the 8-byte union value may not be read from the correct offset.

Problem
On 32-bit Windows, PDH double counters could return obviously corrupted values,
such as extremely large or small numbers, even when:
- the PDH call itself returned ERROR_SUCCESS
- CStatus indicated valid data

This was observed when reading PDH formatted values through the Go
specialization structs.

Change
This PR adds explicit 4-byte padding after CStatus for 8-byte union members:

    type PDH_FMT_COUNTERVALUE_DOUBLE struct {
        CStatus     uint32
        _           uint32
        DoubleValue float64
    }

    type PDH_FMT_COUNTERVALUE_LARGE struct {
        CStatus    uint32
        _          uint32
        LargeValue int64
    }

This keeps the 8-byte value fields aligned with the native PDH layout on
windows/386.

Impact
- fixes corrupted PDH formatted values on 32-bit Windows
- keeps the specialization layout consistent with the native PDH union layout
- does not change API behavior

Notes
This issue was observed on windows/386 when reading PDH formatted counter
values, where the unpadded layout could produce invalid results. The change is
intended to make the struct layout match the native PDH structure more
reliably.